### PR TITLE
don't use `table.` on columns for inserts

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -43,6 +43,8 @@ Postgres.prototype.visitSelect = function(select) {
 Postgres.prototype.visitInsert = function(insert) {
   var self = this;
   this._visitedFrom = true;
+  //don't use table.column for inserts
+  this._visitedInsert = true;
   var paramNodes = insert.nodes.map(function(node) { 
     return self.visit(new Parameter(node.value));
   }).join(', ');
@@ -130,14 +132,16 @@ Postgres.prototype.visitTable = function(tableNode) {
 Postgres.prototype.visitColumn = function(columnNode) {
   var table = columnNode.table;
   var txt = "";
-  if(table.alias) {
-    txt = table.alias;
-  } else if(table.quote) {
-    txt = '"' + table.getName() + '"';
-  } else {
-    txt = table.getName();
+  if(!this._visitedInsert) {
+    if(table.alias) {
+      txt = table.alias;
+    } else if(table.quote) {
+      txt = '"' + table.getName() + '"';
+    } else {
+      txt = table.getName();
+    }
+    txt += '.'
   }
-  txt += '.'
   if(columnNode.quote) {
     return txt += ('"' + columnNode.name + '"');
   }

--- a/test/dialect-tests.js
+++ b/test/dialect-tests.js
@@ -136,19 +136,19 @@ console.log('insert');
 
 test({
   query : post.insert(post.content.value('test'), post.userId.value(1)),
-  pg    : 'INSERT INTO post (post.content, post."userId") VALUES ($1, $2)',
+  pg    : 'INSERT INTO post (content, "userId") VALUES ($1, $2)',
   params: ['test', 1]
 });
 
 test({
   query : post.insert(post.content.value('whoah')),
-  pg    : 'INSERT INTO post (post.content) VALUES ($1)',
+  pg    : 'INSERT INTO post (content) VALUES ($1)',
   params: ['whoah']
 });
 
 test({
   query : post.insert({content: 'test', userId: 2}),
-  pg    : 'INSERT INTO post (post.content, post."userId") VALUES ($1, $2)',
+  pg    : 'INSERT INTO post (content, "userId") VALUES ($1, $2)',
   params: ['test', 2]
 });
 


### PR DESCRIPTION
Using `table.` context for column names in insert statements is invalid.
