### PR TITLE
Add support for left joins and subqueries.

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -80,6 +80,10 @@ Table.prototype.join = function(other) {
   return new JoinNode('INNER', this.toNode(), other.toNode());
 }
 
+Table.prototype.leftJoin = function(other) {
+  return new JoinNode('LEFT', this.toNode(), other.toNode());
+}
+
 Table.prototype.as = function(alias) {
   //TODO could this be cleaner?
   var t = Table.define(this._initialConfig);

--- a/test/dialect-tests.js
+++ b/test/dialect-tests.js
@@ -93,8 +93,13 @@ test({
 });
 
 test({
-  query : user.select(user.name, post.content).from(user.join(post).on(user.id.equals(post.userId))),
-  pg    : 'SELECT "user"."name", "post"."content" FROM "user" INNER JOIN "post" ON ("user"."id" = "post"."userId")'
+  query : user.select(user.name, post.content).from(user.leftJoin(post).on(user.id.equals(post.userId))),
+  pg    : 'SELECT "user"."name", "post"."content" FROM "user" LEFT JOIN "post" ON ("user"."id" = "post"."userId")'
+});
+
+test({
+  query : user.select(user.name.as('user name'), user.id.as('user id')).from(user),
+  pg    : 'SELECT "user"."name" as "user name", "user"."id" as "user id" FROM "user"'
 });
 
 test({


### PR DESCRIPTION
Adding support for left joins, and to make them useful, subqueries. The left join addition was pretty straightforward, but I think the subquery functionality needs to be reviewed. Tests are passing but I feel like things could be a bit cleaner. 

Right now, subquery nodes are just Query nodes with the type changed to 'SUBQUERY' and a table alias added; it'd probably be best to have a `lib/node/subquery` file, but to make that a reality the common functionality between subquery and query would need to be abstracted out, and I didn't think I should go down that path without input!
