### PR TITLE
Add support for setting to columns in addition to parameters in UPDATEs

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -72,7 +72,7 @@ Postgres.prototype.visitUpdate = function(update) {
   this._visitedFrom = true;
   var params = [];
   for(var i = 0, node; node = update.nodes[i]; i++) {
-    params = params.concat(this.visit(node) + ' = ' + this.visit(new Parameter(node.value)));
+    params = params.concat(this.visit(node) + ' = ' + this.visit(node.value));
   }
   var result = [
     'UPDATE',

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -8,6 +8,7 @@ var Insert = require(__dirname + '/insert');
 var Update = require(__dirname + '/update');
 var Delete = require(__dirname + '/delete');
 var Returning = require(__dirname + '/returning');
+var ParameterNode = require(__dirname + '/parameter');
 
 var Modifier = Node.define({
   constructor: function(table, type, count) {
@@ -85,7 +86,8 @@ var Query = Node.define({
     var self = this;
     var update = new Update();
     Object.keys(o).forEach(function(key) {
-      update.add(self.table[key].value(o[key]));
+      var val = o[key];
+      update.add(self.table[key].value(val.toNode ? val.toNode() : new ParameterNode(val)));
     });
     return this.add(update);
   },

--- a/test/dialect-tests.js
+++ b/test/dialect-tests.js
@@ -260,6 +260,11 @@ test({
   params: ['']
 });
 
+test({
+  query : post.update({content: user.name}).from(user).where(post.userId.equals(user.id)),
+  pg    : 'UPDATE "post" SET "content" = "name" FROM "user" WHERE ("post"."userId" = "user"."id")',
+  params: []
+});
 
 var ignore = function() {
   var parent = post.select(post.content);


### PR DESCRIPTION
@brianc: Currently, it's not possible to do an `UPDATE table1 SET table1.col1 = table2.col2 ...` because updates assume a `ParameterNode()`.

I've made it work, but I'm not sure about my implementation because there is probably other code relying on `this.value` being a raw value instead of a `Node`. I couldn't think of another way off the top of my head that wouldn't have a significant impact on the API... any ideas?
