### PR TITLE
Added ALTER TABLE support (add/drop column)

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -21,6 +21,7 @@ Postgres.prototype.visit = function(node) {
     case 'UPDATE': return this.visitUpdate(node);
     case 'DELETE': return this.visitDelete();
     case 'CREATE': return this.visitCreate();
+    case 'ALTER': return this.visitAlter(node);
     case 'FROM': return this.visitFrom(node);
     case 'WHERE': return this.visitWhere(node);
     case 'ORDER BY': return this.visitOrderBy(node);
@@ -34,6 +35,8 @@ Postgres.prototype.visit = function(node) {
     case 'UNARY': return this.visitUnary(node);
     case 'PARAMETER': return this.visitParameter(node);
     case 'DEFAULT': return this.visitDefault(node);
+    case 'ADD COLUMN': return this.visitAddColumn(node);
+    case 'DROP COLUMN': return this.visitDropColumn(node);
     case 'LIMIT':
     case 'OFFSET':
       return this.visitModifier(node);
@@ -111,6 +114,22 @@ Postgres.prototype.visitCreate = function() {
     '(' + col_nodes.map(this.visit.bind(this)).join(', ') + ')'
   ];
   this._visitingCreate = false;
+  return result;
+}
+
+Postgres.prototype.visitAlter = function(alter) {
+  this._visitingAlter = true;
+  //don't auto-generate from clause
+  this._visitedFrom = true;
+  var table = this._queryNode.table;
+  var col_nodes = table.columns.map(function(col) { return col.toNode(); });
+  console.log('nodes.length: ' + alter.nodes.length);
+  var result = [
+    'ALTER TABLE',
+    this.visit(table.toNode()),
+    alter.nodes.map(this.visit.bind(this)).join(', ')
+  ];
+  this._visitingAlter = false;
   return result;
 }
 
@@ -213,7 +232,7 @@ Postgres.prototype.visitColumn = function(columnNode) {
   if(inSelectClause && columnNode.asArray) {
     txt += 'array_agg(';
   }
-  if(!this._visitedInsert && !this._visitingUpdate && !this._visitingCreate) {
+  if(!this._visitedInsert && !this._visitingUpdate && !this._visitingCreate && !this._visitingAlter) {
     if(table.alias) {
       txt = table.alias;
     } else {
@@ -233,7 +252,7 @@ Postgres.prototype.visitColumn = function(columnNode) {
   else if(inSelectClause && columnNode.alias) {
     txt += ' as ' + this.quote(columnNode.alias);
   }
-  if(this._visitingCreate)
+  if(this._visitingCreate || this._visitingAddColumn)
     txt += ' ' + columnNode.dataType;
   return txt;
 }
@@ -247,6 +266,17 @@ Postgres.prototype.visitDefault = function(parameter) {
   var params = this.params;
   this.params.push('DEFAULT');
   return "$"+params.length;
+}
+
+Postgres.prototype.visitAddColumn = function(addColumn) {
+  this._visitingAddColumn = true;
+  var result = ['ADD COLUMN ' + this.visit(addColumn.nodes[0])]
+  this._visitingAddColumn = false;
+  return result;
+}
+
+Postgres.prototype.visitDropColumn = function(dropColumn) {
+  return ['DROP COLUMN ' + this.visit(dropColumn.nodes[0])];
 }
 
 Postgres.prototype.visitJoin = function(join) {

--- a/lib/node/addColumn.js
+++ b/lib/node/addColumn.js
@@ -1,0 +1,5 @@
+var Node = require(__dirname);
+
+module.exports = Node.define({
+  type: 'ADD COLUMN'
+});

--- a/lib/node/alter.js
+++ b/lib/node/alter.js
@@ -1,0 +1,5 @@
+var Node = require(__dirname);
+
+module.exports = Node.define({
+  type: 'ALTER'
+});

--- a/lib/node/dropColumn.js
+++ b/lib/node/dropColumn.js
@@ -1,0 +1,5 @@
+var Node = require(__dirname);
+
+module.exports = Node.define({
+  type: 'DROP COLUMN'
+});

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -9,6 +9,9 @@ var Update = require(__dirname + '/update');
 var Delete = require(__dirname + '/delete');
 var Returning = require(__dirname + '/returning');
 var Create = require(__dirname + '/create');
+var Alter = require(__dirname + '/alter');
+var AddColumn = require(__dirname + '/addColumn');
+var DropColumn = require(__dirname + '/dropColumn');
 var ParameterNode = require(__dirname + '/parameter');
 
 var Modifier = Node.define({
@@ -118,6 +121,21 @@ var Query = Node.define({
   },
   create: function() {
     return this.add(new Create());
+  },
+  alter: function() {
+    return this.add(new Alter());
+  },
+  addColumn: function(column) {
+    var addClause = new AddColumn();
+    addClause.add(column.toNode());
+    this.nodes[0].add(addClause);
+    return this;
+  },
+  dropColumn: function(column) {
+    var dropClause = new DropColumn();
+    dropClause.add(column.toNode());
+    this.nodes[0].add(dropClause);
+    return this;
   },
   limit: function(count) {
     return this.add(new Modifier(this, 'LIMIT', count));

--- a/lib/table.js
+++ b/lib/table.js
@@ -87,6 +87,12 @@ Table.prototype.create = function() {
   return query;
 }
 
+Table.prototype.alter = function() {
+  var query = new Query(this);
+  query.alter.apply(query, arguments);
+  return query;
+}
+
 Table.prototype.toNode = function() {
   return new TableNode(this);
 }

--- a/test/postgres/alter-table-tests.js
+++ b/test/postgres/alter-table-tests.js
@@ -1,0 +1,39 @@
+var Harness = require('./support');
+var post = Harness.definePostTable();
+var Table = require(__dirname + '/../../lib/table');
+
+Harness.test({
+  query : post.alter().dropColumn(post.content),
+  pg    : 'ALTER TABLE "post" DROP COLUMN "content"',
+  params: []
+});
+
+Harness.test({
+  query : post.alter().dropColumn(post.content).dropColumn(post.userId),
+  pg    : 'ALTER TABLE "post" DROP COLUMN "content", DROP COLUMN "userId"',
+  params: []
+});
+
+
+var group = Table.define({
+  name: 'group',
+  columns: [{
+    name: 'id',
+    dataType: 'varchar(100)'
+  }, {
+    name: 'userId',
+    dataType: 'varchar(100)'
+  }]
+});
+
+Harness.test({
+  query : group.alter().addColumn(group.id),
+  pg    : 'ALTER TABLE "group" ADD COLUMN "id" varchar(100)',
+  params: []
+});
+
+Harness.test({
+  query : group.alter().addColumn(group.id).addColumn(group.userId),
+  pg    : 'ALTER TABLE "group" ADD COLUMN "id" varchar(100), ADD COLUMN "userId" varchar(100)',
+  params: []
+});


### PR DESCRIPTION
@brianc: Note that I didn't add RENAME support (for renaming columns or renaming tables) because the syntax is a little different and doesn't support multiple actions in the same statement like add/drop columns do (see: http://www.postgresql.org/docs/9.2/static/sql-altertable.html)

Also, I hung the add/drop column nodes on the alter node instead of adding them directly to the query node because I needed to comma-delimit them in `visitAlter()`. Perhaps there's a better way to deal with that...
