### PR TITLE
Fix update query regression

### DIFF
--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -100,7 +100,7 @@ var Query = Node.define({
     var update = new Update();
     Object.keys(o).forEach(function(key) {
       var val = o[key];
-      update.add(self.table[key].value(val.toNode ? val.toNode() : new ParameterNode(val)));
+      update.add(self.table[key].value(val && val.toNode ? val.toNode() : new ParameterNode(val)));
     });
     return this.add(update);
   },

--- a/test/postgres/update-tests.js
+++ b/test/postgres/update-tests.js
@@ -15,6 +15,12 @@ Harness.test({
 });
 
 Harness.test({
+  query : post.update({content: null, userId: 3}),
+  pg    : 'UPDATE "post" SET "content" = $1, "userId" = $2',
+  params: [null, 3]
+});
+
+Harness.test({
   query : post.update({content: 'test', userId: 3}).where(post.content.equals('no')),
   pg    : 'UPDATE "post" SET "content" = $1, "userId" = $2 WHERE ("post"."content" = $3)',
   params: ['test', 3, 'no']


### PR DESCRIPTION
A regression was introduced with a previous merge that breaks any updates where a value is null. This patch adds a test for the condition, and a fix.
