### PR TITLE
Added DROP TABLE support and IF (NOT) EXISTS

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -20,7 +20,8 @@ Postgres.prototype.visit = function(node) {
     case 'INSERT': return this.visitInsert(node);
     case 'UPDATE': return this.visitUpdate(node);
     case 'DELETE': return this.visitDelete();
-    case 'CREATE': return this.visitCreate();
+    case 'CREATE': return this.visitCreate(node);
+    case 'DROP': return this.visitDrop(node);
     case 'FROM': return this.visitFrom(node);
     case 'WHERE': return this.visitWhere(node);
     case 'ORDER BY': return this.visitOrderBy(node);
@@ -34,6 +35,8 @@ Postgres.prototype.visit = function(node) {
     case 'UNARY': return this.visitUnary(node);
     case 'PARAMETER': return this.visitParameter(node);
     case 'DEFAULT': return this.visitDefault(node);
+    case 'IF EXISTS': return this.visitIfExists();
+    case 'IF NOT EXISTS': return this.visitIfNotExists();
     case 'LIMIT':
     case 'OFFSET':
       return this.visitModifier(node);
@@ -99,18 +102,27 @@ Postgres.prototype.visitDelete = function() {
   return ['DELETE'];
 }
 
-Postgres.prototype.visitCreate = function() {
+Postgres.prototype.visitCreate = function(create) {
   this._visitingCreate = true;
   //don't auto-generate from clause
   this._visitedFrom = true;
   var table = this._queryNode.table;
   var col_nodes = table.columns.map(function(col) { return col.toNode(); });
-  var result = [
-    'CREATE TABLE',
-    this.visit(table.toNode()),
-    '(' + col_nodes.map(this.visit.bind(this)).join(', ') + ')'
-  ];
+  
+  var result = ['CREATE TABLE'];
+  result = result.concat(create.nodes.map(this.visit.bind(this)));
+  result.push(this.visit(table.toNode()));
+  result.push('(' + col_nodes.map(this.visit.bind(this)).join(', ') + ')');
   this._visitingCreate = false;
+  return result;
+}
+
+Postgres.prototype.visitDrop = function(drop) {
+  //don't auto-generate from clause
+  this._visitedFrom = true;
+  var result = ['DROP TABLE'];
+  result = result.concat(drop.nodes.map(this.visit.bind(this)));
+  result.push(this.visit(this._queryNode.table.toNode()));
   return result;
 }
 
@@ -247,6 +259,14 @@ Postgres.prototype.visitDefault = function(parameter) {
   var params = this.params;
   this.params.push('DEFAULT');
   return "$"+params.length;
+}
+
+Postgres.prototype.visitIfExists = function() {
+  return ['IF EXISTS'];
+}
+
+Postgres.prototype.visitIfNotExists = function() {
+  return ['IF NOT EXISTS'];
 }
 
 Postgres.prototype.visitJoin = function(join) {

--- a/lib/node/drop.js
+++ b/lib/node/drop.js
@@ -1,0 +1,5 @@
+var Node = require(__dirname);
+
+module.exports = Node.define({
+  type: 'DROP'
+});

--- a/lib/node/ifExists.js
+++ b/lib/node/ifExists.js
@@ -1,0 +1,5 @@
+var Node = require(__dirname);
+
+module.exports = Node.define({
+  type: 'IF EXISTS'
+});

--- a/lib/node/ifNotExists.js
+++ b/lib/node/ifNotExists.js
@@ -1,0 +1,5 @@
+var Node = require(__dirname);
+
+module.exports = Node.define({
+  type: 'IF NOT EXISTS'
+});

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -9,7 +9,10 @@ var Update = require(__dirname + '/update');
 var Delete = require(__dirname + '/delete');
 var Returning = require(__dirname + '/returning');
 var Create = require(__dirname + '/create');
+var Drop = require(__dirname + '/drop');
 var ParameterNode = require(__dirname + '/parameter');
+var IfExists = require(__dirname + '/ifExists');
+var IfNotExists = require(__dirname + '/ifNotExists');
 
 var Modifier = Node.define({
   constructor: function(table, type, count) {
@@ -119,11 +122,22 @@ var Query = Node.define({
   create: function() {
     return this.add(new Create());
   },
+  drop: function() {
+    return this.add(new Drop());
+  },
   limit: function(count) {
     return this.add(new Modifier(this, 'LIMIT', count));
   },
   offset: function(count) {
     return this.add(new Modifier(this, 'OFFSET', count));
+  },
+  ifExists: function() {
+    this.nodes[0].add(new IfExists());
+    return this;
+  },
+  ifNotExists: function() {
+    this.nodes[0].add(new IfNotExists());
+    return this;
   },
   toQuery: function() {
     var Dialect = require(__dirname + '/../').dialect;

--- a/lib/table.js
+++ b/lib/table.js
@@ -87,6 +87,12 @@ Table.prototype.create = function() {
   return query;
 }
 
+Table.prototype.drop = function() {
+  var query = new Query(this);
+  query.drop.apply(query, arguments);
+  return query;
+}
+
 Table.prototype.toNode = function() {
   return new TableNode(this);
 }

--- a/test/postgres/create-table-tests.js
+++ b/test/postgres/create-table-tests.js
@@ -17,3 +17,9 @@ Harness.test({
   pg    : 'CREATE TABLE "group" ("id" varchar(100), "user_id" varchar(100))',
   params: []
 });
+
+Harness.test({
+  query : group.create().ifNotExists(),
+  pg    : 'CREATE TABLE IF NOT EXISTS "group" ("id" varchar(100), "user_id" varchar(100))',
+  params: []
+});

--- a/test/postgres/drop-table-tests.js
+++ b/test/postgres/drop-table-tests.js
@@ -1,0 +1,14 @@
+var Harness = require('./support');
+var post = Harness.definePostTable();
+
+Harness.test({
+  query : post.drop(),
+  pg    : 'DROP TABLE "post"',
+  params: []
+});
+
+Harness.test({
+  query : post.drop().ifExists(),
+  pg    : 'DROP TABLE IF EXISTS "post"',
+  params: []
+});


### PR DESCRIPTION
@brianc: I added the `IF (NOT) EXISTS` node to the drop/create node directly, rather than the query node, so that `visitCreate()`/`visitDrop()` could put things in the right order (inject the `IF (NOT) EXISTS` modifier before the table name). Let me know if there's a different way you'd like me to do things...
