### PR TITLE
Added support for passing an object to .where()

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var assert = require('assert');
 var From = require(__dirname + '/../node/from');
 var Parameter = require(__dirname + '/../node/parameter');
 var Postgres = function() {
@@ -263,8 +264,11 @@ Postgres.prototype.visitColumn = function(columnNode) {
   else if(inSelectClause && columnNode.alias) {
     txt += ' as ' + this.quote(columnNode.alias);
   }
-  if(this._visitingCreate || this._visitingAddColumn)
+  if(this._visitingCreate || this._visitingAddColumn) {
+    assert(columnNode.dataType, 'dataType missing for column ' + columnNode.name +
+      ' (CREATE TABLE and ADD COLUMN statements require a dataType)');
     txt += ' ' + columnNode.dataType;
+  }
   return txt;
 }
 

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -16,6 +16,7 @@ var DropColumn = require(__dirname + '/dropColumn');
 var ParameterNode = require(__dirname + '/parameter');
 var IfExists = require(__dirname + '/ifExists');
 var IfNotExists = require(__dirname + '/ifNotExists');
+var Column = require(__dirname + '/../column');
 
 var Modifier = Node.define({
   constructor: function(table, type, count) {
@@ -44,11 +45,27 @@ var Query = Node.define({
     return this.add(from);
   },
   where: function(node) {
+    if (!node.toNode && typeof node == 'object')
+      node = this._whereObject(node);
+
     //calling #where twice functions like calling #where & then #and
     if(this.whereClause) return this.and(node);
     this.whereClause = new Where();
     this.whereClause.add(node);
     return this.add(this.whereClause);
+  },
+  _whereObject: function(node) {
+    var result;
+    for (var colName in node) {
+      var column = new Column({name: colName, table: this.table});
+      var query = column.equals(node[colName]);
+
+      if (!result)
+        result = query;
+      else
+        result.and(query);
+    }
+    return result;
   },
   or: function(node) {
     this.whereClause.or(node);

--- a/test/postgres/table-tests.js
+++ b/test/postgres/table-tests.js
@@ -91,3 +91,8 @@ Harness.test({
   query : user.select('name').from('user').where('name <> NULL'),
   pg    : 'SELECT name FROM user WHERE name <> NULL'
 });
+
+Harness.test({
+  query : user.select('name').from('user').where({name: 'brian'}),
+  pg    : 'SELECT name FROM user WHERE ("user"."name" = $1)'
+});


### PR DESCRIPTION
@brianc: This adds a `.where({name: 'brian'})` syntax option.
