### PR TITLE
update() needs to prefixes source columns

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -84,13 +84,14 @@ Postgres.prototype.visitInsert = function(insert) {
 }
 
 Postgres.prototype.visitUpdate = function(update) {
-  //don't prefix columns with table names
-  this._visitingUpdate = true;
   //don't auto-generate from clause
   this._visitedFrom = true;
   var params = [];
   for(var i = 0, node; node = update.nodes[i]; i++) {
-    params = params.concat(this.visit(node) + ' = ' + this.visit(node.value));
+    this._visitingUpdateTargetColumn = true;
+    var target_col = this.visit(node);
+    this._visitingUpdateTargetColumn = false;
+    params = params.concat(target_col + ' = ' + this.visit(node.value));
   }
   var result = [
     'UPDATE',
@@ -98,7 +99,6 @@ Postgres.prototype.visitUpdate = function(update) {
     'SET',
     params.join(', ')
   ];
-  this._visitingUpdate = false;
   return result;
 }
 
@@ -245,7 +245,7 @@ Postgres.prototype.visitColumn = function(columnNode) {
   if(inSelectClause && columnNode.asArray) {
     txt += 'array_agg(';
   }
-  if(!this._visitedInsert && !this._visitingUpdate && !this._visitingCreate && !this._visitingAlter) {
+  if(!this._visitedInsert && !this._visitingUpdateTargetColumn && !this._visitingCreate && !this._visitingAlter) {
     if(table.alias) {
       txt = table.alias;
     } else {

--- a/test/postgres/update-tests.js
+++ b/test/postgres/update-tests.js
@@ -28,7 +28,13 @@ Harness.test({
 
 Harness.test({
   query : post.update({content: user.name}).from(user).where(post.userId.equals(user.id)),
-  pg    : 'UPDATE "post" SET "content" = "name" FROM "user" WHERE ("post"."userId" = "user"."id")',
+  pg    : 'UPDATE "post" SET "content" = "user"."name" FROM "user" WHERE ("post"."userId" = "user"."id")',
   params: []
 });
 
+// update() needs to prefix ambiguous source columns; prefixing target columns is not allowed
+Harness.test({
+  query : post.update({userId: user.id}).from(user).where(post.userId.equals(user.id)),
+  pg    : 'UPDATE "post" SET "userId" = "user"."id" FROM "user" WHERE ("post"."userId" = "user"."id")',
+  params: []
+});


### PR DESCRIPTION
`update()` needs to prefix source columns in an update statement with the table name in case they are ambiguous (for instance `id`, where the update has joined another table with an `id` column)
