### PR TITLE
Added aggregate COUNT function

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ var query = user
     ).or(
       user.name.equals('bang').and(user.id.equals(2))
     ).toQuery();
-    
+
 //query is parameterized by default
 console.log(query.text); //SELECT "user"."id" FROM "user" WHERE ((("user"."name" = $1) AND ("user"."id" = $2)) OR (("user"."name" = $3) AND ("user"."id" = $4)))
 
@@ -49,11 +49,11 @@ console.log(query.values); //['boom', 1, 'bang', 2]
 //how about a join?
 var query = user.select(user.name, post.content)
   .from(user.join(post).on(user.id.equals(post.userId))).toQuery();
-  
+
 console.log(query.text); //'SELECT "user"."name", "post"."content" FROM "user" INNER JOIN "post" ON ("user"."id" = "post"."userId")'
 ```
 
-There are a __lot__ more examples under `test/dialect-tests.js`
+There are a __lot__ more examples included in the `test` folder.
 
 ## contributing
 
@@ -75,7 +75,7 @@ Once the tests are passing, modify as you see fit.  _Please_ make sure you write
 
 __As long as your pull request doesn't have completely off-the-wall changes and it does have tests I will almost always merge it right away and push it to npm__
 
-If you think your changes are too off-the-wall, open an issue or a pull-request without code so we can discuss them.  
+If you think your changes are too off-the-wall, open an issue or a pull-request without code so we can discuss them.
 
 __Seriously:__
 

--- a/lib/column.js
+++ b/lib/column.js
@@ -6,6 +6,7 @@ var TextNode = require(__dirname + '/node/text');
 var Column = function(config) {
   this.table = config.table;
   this.name = config.name;
+  this.star = config.star;
   this.asc = this.ascending = this;
   this.alias = null;
   this.desc = this.descending = new BinaryNode({
@@ -75,6 +76,13 @@ Column.prototype.arrayAgg = function(alias) {
   var context = contextify(this);
   context.asArray = true;
   context.alias = alias || context.name + 's';
+  return new ColumnNode(context);
+}
+
+Column.prototype.count = function(alias) {
+  var context = contextify(this);
+  context.aggCount = true;
+  context.alias = alias || context.name + '_count';
   return new ColumnNode(context);
 }
 

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -113,7 +113,7 @@ Postgres.prototype.visitCreate = function(create) {
   this._visitedFrom = true;
   var table = this._queryNode.table;
   var col_nodes = table.columns.map(function(col) { return col.toNode(); });
-  
+
   var result = ['CREATE TABLE'];
   result = result.concat(create.nodes.map(this.visit.bind(this)));
   result.push(this.visit(table.toNode()));
@@ -242,8 +242,12 @@ Postgres.prototype.visitColumn = function(columnNode) {
   var table = columnNode.table;
   var inSelectClause = !this._selectOrDeleteEndIndex;
   var txt = "";
-  if(inSelectClause && columnNode.asArray) {
-    txt += 'array_agg(';
+  if(inSelectClause) {
+    if (columnNode.asArray) {
+      txt += 'array_agg(';
+    } else if (columnNode.aggCount) {
+      txt += 'COUNT(';
+    }
   }
   if(!this._visitedInsert && !this._visitingUpdateTargetColumn && !this._visitingCreate && !this._visitingAlter) {
     if(table.alias) {
@@ -257,12 +261,15 @@ Postgres.prototype.visitColumn = function(columnNode) {
     }
     txt += '.';
   }
-  txt += this.quote(columnNode.name);
-  if(inSelectClause && columnNode.asArray) {
-    txt += ')';
-    txt += ' as ' + this.quote(columnNode.alias);
+  if (columnNode.star) {
+    txt += '*';
+  } else {
+    txt += this.quote(columnNode.name);
   }
-  else if(inSelectClause && columnNode.alias) {
+  if(inSelectClause && (columnNode.asArray || columnNode.aggCount)) {
+    txt += ')';
+  }
+  if(inSelectClause && columnNode.alias) {
     txt += ' as ' + this.quote(columnNode.alias);
   }
   if(this._visitingCreate || this._visitingAddColumn) {

--- a/lib/node/column.js
+++ b/lib/node/column.js
@@ -5,9 +5,15 @@ module.exports = Node.define({
   constructor: function(config) {
     this.name = config.name;
     this.alias = config.alias;
+    this.star = config.star;
     this.asArray = config.asArray;
+    this.aggCount = config.aggCount;
     this.table = config.table;
     this.value = config.getValue();
     this.dataType = config.dataType;
+  },
+  as: function(alias) {
+    this.alias = alias;
+    return this;
   }
 });

--- a/lib/table.js
+++ b/lib/table.js
@@ -48,6 +48,12 @@ Table.prototype.star = function() {
   return new TextNode('"'+name+'".*');
 }
 
+Table.prototype.count = function(alias) {
+  var name = this.alias || this._name,
+    col = new Column({table: this, star: true});
+  return col.count(alias || name + '_count'); //ColumnNode
+}
+
 Table.prototype.select = function() {
   //create the query and pass it off
   var query = new Query(this);

--- a/test/postgres/aggregate-tests.js
+++ b/test/postgres/aggregate-tests.js
@@ -1,0 +1,33 @@
+var Harness = require('./support');
+var user = Harness.defineUserTable();
+var post = Harness.definePostTable();
+
+Harness.test({
+  query : post.select(post.count()),
+  pg    : 'SELECT COUNT("post".*) as "post_count" FROM "post"'
+});
+
+Harness.test({
+  query : post.select(post.count('post_count')),
+  pg    : 'SELECT COUNT("post".*) as "post_count" FROM "post"'
+});
+
+Harness.test({
+  query : post.select(post.count().as('post_amount')),
+  pg    : 'SELECT COUNT("post".*) as "post_amount" FROM "post"'
+});
+
+Harness.test({
+  query : post.select(post.content.count()),
+  pg    : 'SELECT COUNT("post"."content") as "content_count" FROM "post"'
+});
+
+Harness.test({
+  query : post.select(post.content.count('content_count')),
+  pg    : 'SELECT COUNT("post"."content") as "content_count" FROM "post"'
+});
+
+Harness.test({
+  query : post.select(post.content.count().as('content_count')),
+  pg    : 'SELECT COUNT("post"."content") as "content_count" FROM "post"'
+});


### PR DESCRIPTION
Added aggregate COUNT function per issue #8.

API added:
- `Table.count([alias])` returns ColumnNode
- `Column.count([alias])` returns ColumnNode
- `ColumnNode.as(alias)` returns ColumnNode

Properties added:
- `Column.star` **boolean** Allows for the field name to be an unquoted `*`
- `ColumnNode.star` **boolean** Allows for the field name to be an unquoted `*`
- `ColumnNode.aggCount` **boolean** Triggers the use of the `COUNT()` function.

Tests written in `tests/postgres/aggregate_tests.js`
