### PR TITLE
Fix ORDER BY syntax error in PG

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -176,7 +176,7 @@ Postgres.prototype.visitOrderBy = function(orderBy) {
 
 Postgres.prototype.visitOrderByColumn = function(column) {
   if(column.direction) {
-    return '(' + this.visit(column.column) + ' ' + this.visit(column.direction) + ')';
+    return this.visit(column.column) + ' ' + this.visit(column.direction);
   } else {
     return this.visit(column.column);
   }

--- a/test/dialects/order-tests.js
+++ b/test/dialects/order-tests.js
@@ -12,12 +12,12 @@ Harness.test({
 
 Harness.test({
   query : post.select(post.content).order(post.content, post.userId.descending),
-  pg    : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content", ("post"."userId" DESC)',
+  pg    : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content", "post"."userId" DESC',
   mysql : 'SELECT `post`.`content` FROM `post` ORDER BY `post`.`content`, `post`.`userId` DESC'
 });
 
 Harness.test({
   query : post.select(post.content).order(post.content.asc, post.userId.desc),
-  pg    : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content", ("post"."userId" DESC)',
+  pg    : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content", "post"."userId" DESC',
   mysql : 'SELECT `post`.`content` FROM `post` ORDER BY `post`.`content`, `post`.`userId` DESC'
 });


### PR DESCRIPTION
Maybe this is just a PG >= 9.1 thing? But I'm getting a syntax error for

``` sql
... ORDER BY ("table"."column" DESC)
```

but not for 

``` sql
... ORDER BY "table"."column" DESC
```

This fixes that problem.
