### PR TITLE
Allow plain text expressions in where(), and() and or()

### DIFF
--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -70,7 +70,7 @@ var Query = Node.define({
     //calling #where twice functions like calling #where & then #and
     if(this.whereClause) return this.and(node);
     this.whereClause = new Where();
-    this.whereClause.add(node);
+    this.whereClause.add( this.whereClause.expr(node) );
     return this.add(this.whereClause);
   },
   _whereObject: function(node) {

--- a/lib/node/where.js
+++ b/lib/node/where.js
@@ -1,20 +1,24 @@
 'use strict';
 
 var BinaryNode = require(__dirname + '/binary');
+var TextNode = require(__dirname + '/text');
 module.exports = require(__dirname).define({
   type: 'WHERE',
+  expr: function(other) {
+    return typeof other === 'string' ? new TextNode('('+other+')') : other;
+  },
   or: function(other) {
     return this.nodes.push(new BinaryNode({
       left: this.nodes.pop(),
       operator: 'OR',
-      right: other
+      right: this.expr(other)
     }));
   },
   and: function(other) {
     return this.nodes.push(new BinaryNode({
       left: this.nodes.pop(),
       operator: 'AND',
-      right: other
+      right: this.expr(other)
     }));
   }
 });

--- a/test/dialects/table-tests.js
+++ b/test/dialects/table-tests.js
@@ -120,24 +120,33 @@ Harness.test({
 
 Harness.test({
   query : user.select('name').from('user').where('name <> NULL'),
-  pg    : 'SELECT name FROM user WHERE name <> NULL',
-  sqlite: 'SELECT name FROM user WHERE name <> NULL',
-  mysql : 'SELECT name FROM user WHERE name <> NULL',
+  pg    : 'SELECT name FROM user WHERE (name <> NULL)',
+  sqlite: 'SELECT name FROM user WHERE (name <> NULL)',
+  mysql : 'SELECT name FROM user WHERE (name <> NULL)',
   params: []
 });
 
 Harness.test({
   query : user.select('name,id').from('user').where('name <> NULL'),
-  pg    : 'SELECT name,id FROM user WHERE name <> NULL',
-  sqlite: 'SELECT name,id FROM user WHERE name <> NULL',
-  mysql : 'SELECT name,id FROM user WHERE name <> NULL',
+  pg    : 'SELECT name,id FROM user WHERE (name <> NULL)',
+  sqlite: 'SELECT name,id FROM user WHERE (name <> NULL)',
+  mysql : 'SELECT name,id FROM user WHERE (name <> NULL)',
   params: []
 });
 
 Harness.test({
   query : user.select('name','id').from('user').where('name <> NULL'),
-  pg    : 'SELECT name, id FROM user WHERE name <> NULL',
-  mysql : 'SELECT name, id FROM user WHERE name <> NULL',
+  pg    : 'SELECT name, id FROM user WHERE (name <> NULL)',
+  sqlite: 'SELECT name, id FROM user WHERE (name <> NULL)',
+  mysql : 'SELECT name, id FROM user WHERE (name <> NULL)',
+  params: []
+});
+
+Harness.test({
+  query : user.select('name','id').from('user').where('name <> NULL').and('id <> NULL'),
+  pg    : 'SELECT name, id FROM user WHERE ((name <> NULL) AND (id <> NULL))',
+  sqlite: 'SELECT name, id FROM user WHERE ((name <> NULL) AND (id <> NULL))',
+  mysql : 'SELECT name, id FROM user WHERE ((name <> NULL) AND (id <> NULL))',
   params: []
 });
 


### PR DESCRIPTION
Allow plain text expressions in where(), and() and or()
This will allow custom complex plaintext sql expressions to be used, for example:

```
mytable
  .select( mytable.star() )
  .where(table.enabled.equals(1))
  .and(' DATE_ADD( mytable.lastRun, INTERVAL mytable.freq MINUTE) < NOW() ');
```
