### PR TITLE
Fix subQuery when used as a binary right

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -231,17 +231,9 @@ Postgres.prototype.visitQuery = function(queryNode) {
 Postgres.prototype.visitSubquery = function(queryNode) {
   var subQuery = new this._myClass();
   subQuery.visitQuery(queryNode);
+  var alias = queryNode.alias;
   this.params = this.params.concat(subQuery.params);
-
-  var result = subQuery.output;
-
-  result[0] = '('+result[0];
-  result[result.length-1] = result[result.length-1] + ')';
-  if(queryNode.alias) {
-    result[result.length-1] = result[result.length-1] + ' ' + queryNode.alias;
-  }
-
-  return result;
+  return '(' + subQuery.output.join(' ') + ')' + (alias ? ' ' + alias : '');
 };
 
 Postgres.prototype.visitTable = function(tableNode) {

--- a/test/dialects/table-tests.js
+++ b/test/dialects/table-tests.js
@@ -165,3 +165,11 @@ Harness.test({
   mysql : 'SELECT `user`.`name` AS `quote"quote"tick``tick``` FROM `user`',
   params: []
 });
+
+Harness.test({
+  query : user.select(user.star()).where(user.id['in'](user.subQuery().select(user.id))),
+  pg    : 'SELECT "user".* FROM "user" WHERE ("user"."id" IN (SELECT "user"."id" FROM "user"))',
+  sqlite: 'SELECT "user".* FROM "user" WHERE ("user"."id" IN (SELECT "user"."id" FROM "user"))',
+  mysql : 'SELECT `user`.* FROM `user` WHERE (`user`.`id` IN (SELECT `user`.`id` FROM `user`))',
+  params: []
+});


### PR DESCRIPTION
All that was missing was the `.join(' ')`, but I simplified the code a bit. New test for a subQuery as a right binary and all tests are passing. The problem in the current build is that `output` isn't `join(' ')`d which leaves the query `toString`'d, putting commas where spaces should be.
