### PR TITLE
Add support for table.column.toQuery()

### DIFF
--- a/lib/column.js
+++ b/lib/column.js
@@ -97,6 +97,10 @@ Column.prototype.distinct = function() {
   return new ColumnNode(context);
 };
 
+Column.prototype.toQuery = function() {
+  return this.toNode().toQuery();
+};
+
 binaryMethod('equals', '=');
 binaryMethod('equal', '=');
 binaryMethod('notEqual', '<>');

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var From = require(__dirname + '/../node/from');
 var Select = require(__dirname + '/../node/select');
+var Table = require(__dirname + '/../table');
 var Postgres = function() {
   this.output = [];
   this.params = [];
@@ -14,7 +15,7 @@ Postgres.prototype._arrayAggFunctionName = 'array_agg';
 
 Postgres.prototype.getQuery = function(queryNode) {
   //passed in a table, not a query
-  if(queryNode.name) {
+  if(queryNode instanceof Table) {
     queryNode = queryNode.select(queryNode.star());
   }
   this.output = this.visit(queryNode);
@@ -330,7 +331,7 @@ Postgres.prototype.visitColumn = function(columnNode) {
       ' (CREATE TABLE and ADD COLUMN statements require a dataType)');
     txt += ' ' + columnNode.dataType;
   }
-  return txt;
+  return [txt];
 };
 
 Postgres.prototype.visitParameter = function(parameter) {

--- a/test/column-tests.js
+++ b/test/column-tests.js
@@ -1,0 +1,27 @@
+var assert = require('assert');
+var sql = require(__dirname + '/../lib');
+
+describe('column', function() {
+  var table = sql.define({
+    name: 'user',
+    columns: ['id', 'created']
+  });
+  
+  it('can be accessed by property and array', function() {
+    assert.equal(table.created, table.columns[1], 'should be able to access created both by array and property');
+  });
+
+  describe('toQuery()', function() {
+    it('works', function() {
+      assert.equal(table.id.toQuery().text, '"user"."id"');
+    });
+
+    it('respects AS rename', function() {
+      assert.equal(table.id.as('userId').toQuery().text, '"user"."id" AS "userId"');
+    });
+
+    it('respects count and distinct', function() {
+      assert.equal(table.id.count().distinct().as("userIdCount").toQuery().text, 'COUNT(DISTINCT("user"."id")) AS "userIdCount"');
+    });
+  });
+});


### PR DESCRIPTION
Add tests to support the behavior.

This allows you to do the following:

``` js
table.column.toQuery().text//  "table"."column"
```

Works with column.as('otherName') and .count() and .distinct()
