### PR TITLE
fix multi-field object in where clause bug

### DIFF
--- a/lib/node/where.js
+++ b/lib/node/where.js
@@ -17,7 +17,7 @@ var normalizeNode = function(table, node) {
       if (!result)
         result = query;
       else
-        result.and(query);
+        result = result.and(query);
     }
   }
   return result;

--- a/test/dialects/table-tests.js
+++ b/test/dialects/table-tests.js
@@ -167,6 +167,14 @@ Harness.test({
 });
 
 Harness.test({
+  query : user.select('name').from('user').where({name: 'brian', id: 1}),
+  pg    : 'SELECT name FROM user WHERE (("user"."name" = $1) AND ("user"."id" = $2))',
+  sqlite: 'SELECT name FROM user WHERE (("user"."name" = $1) AND ("user"."id" = $2))',
+  mysql : 'SELECT name FROM user WHERE ((`user`.`name` = ?) AND (`user`.`id` = ?))',
+  params: ['brian', 1]
+});
+
+Harness.test({
   query : user.select(user.name.as('quote"quote"tick`tick`')),
   pg    : 'SELECT "user"."name" AS "quote""quote""tick`tick`" FROM "user"',
   sqlite: 'SELECT "user"."name" AS "quote""quote""tick`tick`" FROM "user"',


### PR DESCRIPTION
When a multi-field object is passed to a where clause, all
fields except the first one were being ignored. This commit
fixes the bug.
