### PR TITLE
Table.prototype.select() creates select with a * if no arguments is provided

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -105,7 +105,11 @@ Table.prototype.count = function(alias) {
 Table.prototype.select = function() {
   //create the query and pass it off
   var query = new Query(this);
-  query.select.apply(query, arguments);
+  if (arguments.length === 0) {
+    query.select.call(query, this.star());
+  } else {
+    query.select.apply(query, arguments);
+  }
   return query;
 };
 

--- a/test/table-tests.js
+++ b/test/table-tests.js
@@ -36,6 +36,11 @@ suite('table', function() {
     assert.equal(sel.type, 'QUERY');
   });
 
+  test('creates *-query if no args is provided to select()', function() {
+    var sel = table.select();
+    assert.ok(sel.nodes[0].nodes[0].star);
+  });
+
   test('can be defined', function() {
     var user = Table.define({
       name: 'user',


### PR DESCRIPTION
I think it's a reasonable default:

```
table.select().toQuery().text == 'SELECT "table".* FROM "table"'
```

Test case is provided.
