### PR TITLE
Add jshint to the devDependencies, update makefile to use local jshint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: jshint test
 
 jshint:
-	jshint lib test
+	./node_modules/.bin/jshint lib test
 
 test:
 	npm test

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "node": "*"
   },
   "dependencies": {
-    "sliced": "0.0.5",
-    "lodash": "~1.2.1"
+    "sliced" : "0.0.5",
+    "lodash" : "~1.2.1"
   },
   "devDependencies": {
-    "mocha": "*"
+    "jshint" : "*",
+    "mocha"  : "*"
   }
 }


### PR DESCRIPTION
Make sense to have jshint to be installed locally instead of requiring the user to have jshint installed globally.
