### PR TITLE
Break out SQL Aliases into its own node

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -33,6 +33,7 @@ Postgres.prototype.visit = function(node) {
     case 'DELETE'          : return this.visitDelete();
     case 'CREATE'          : return this.visitCreate(node);
     case 'DROP'            : return this.visitDrop(node);
+    case 'ALIAS'           : return this.visitAlias(node);
     case 'ALTER'           : return this.visitAlter(node);
     case 'FROM'            : return this.visitFrom(node);
     case 'WHERE'           : return this.visitWhere(node);
@@ -152,6 +153,11 @@ Postgres.prototype.visitDrop = function(drop) {
   var result = ['DROP TABLE'];
   result = result.concat(drop.nodes.map(this.visit.bind(this)));
   result.push(this.visit(this._queryNode.table.toNode()));
+  return result;
+};
+
+Postgres.prototype.visitAlias = function(alias) {
+  var result = [this.visit(alias.value) + ' AS ' + this.quote(alias.alias)];
   return result;
 };
 

--- a/lib/node/alias.js
+++ b/lib/node/alias.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var _ = require('lodash');
+var Node = require(__dirname);
+
+var AliasNode = Node.define({
+  type: 'ALIAS',
+  constructor: function(value, alias) {
+    Node.call(this);
+
+    this.value = value;
+    this.alias = alias;
+  }
+});
+
+var AliasMixin = {
+  as: function(alias) {
+    // create an alias node
+    var aliasNode = new AliasNode(this, alias);
+
+    // defaults the properties of the aliased node
+    _.defaults(aliasNode, this);
+
+    return aliasNode;
+  }
+};
+
+module.exports = AliasNode;
+module.exports.AliasMixin = AliasMixin;

--- a/lib/node/binary.js
+++ b/lib/node/binary.js
@@ -22,4 +22,8 @@ var BinaryNode = Node.define(_.extend({
   },
 }));
 
+// allow aliasing
+var AliasNode = require(__dirname + '/alias');
+_.extend(BinaryNode.prototype, AliasNode.AliasMixin);
+
 module.exports = BinaryNode;

--- a/lib/node/functionCall.js
+++ b/lib/node/functionCall.js
@@ -19,4 +19,8 @@ var FunctionCallNode = Node.define({
 // mix in value expression
 _.extend(FunctionCallNode.prototype, valueExpressionMixin());
 
+// allow aliasing
+var AliasNode = require(__dirname + '/alias');
+_.extend(FunctionCallNode.prototype, AliasNode.AliasMixin);
+
 module.exports = FunctionCallNode;

--- a/lib/node/ternary.js
+++ b/lib/node/ternary.js
@@ -24,4 +24,8 @@ var TernaryNode = Node.define(_.extend({
   },
 }));
 
+// allow aliasing
+var AliasNode = require(__dirname + '/alias');
+_.extend(TernaryNode.prototype, AliasNode.AliasMixin);
+
 module.exports = TernaryNode;

--- a/lib/node/unary.js
+++ b/lib/node/unary.js
@@ -5,7 +5,7 @@ var Node                 = require(__dirname);
 var valueExpressionMixin = require(__dirname + '/valueExpression');
 
 var valueExpressionMixed = false;
-var UnaryNode = module.exports = Node.define({
+var UnaryNode = Node.define({
   type: 'UNARY',
   constructor: function(config) {
     Node.call(this);
@@ -20,3 +20,9 @@ var UnaryNode = module.exports = Node.define({
     }
   }
 });
+
+// allow aliasing
+var AliasNode = require(__dirname + '/alias');
+_.extend(UnaryNode.prototype, AliasNode.AliasMixin);
+
+module.exports = UnaryNode;

--- a/lib/node/valueExpression.js
+++ b/lib/node/valueExpression.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var _        = require('lodash');
-var Node     = require(__dirname);
+var _             = require('lodash');
+var Node          = require(__dirname);
 var ParameterNode = require(__dirname + '/parameter');
 
 // Process values, wrapping them in ParameterNode if necessary.

--- a/test/dialects/alias-tests.js
+++ b/test/dialects/alias-tests.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var Harness = require('./support');
+var customer = Harness.defineCustomerTable();
+var post = Harness.definePostTable();
+var Table = require(__dirname + '/../../lib/table');
+
+Harness.test({
+  query  : customer.select(customer.name.isNull().as('nameIsNull')),
+  pg     : 'SELECT ("customer"."name" IS NULL) AS "nameIsNull" FROM "customer"',
+  sqlite : 'SELECT ("customer"."name" IS NULL) AS "nameIsNull" FROM "customer"',
+  mysql  : 'SELECT (`customer`.`name` IS NULL) AS `nameIsNull` FROM `customer`',
+  params : []
+});
+
+Harness.test({
+  query  : customer.select(customer.name.plus(customer.age).as('nameAndAge')).where(customer.age.gt(10).and(customer.age.lt(20))),
+  pg     : 'SELECT ("customer"."name" + "customer"."age") AS "nameAndAge" FROM "customer" WHERE (("customer"."age" > $1) AND ("customer"."age" < $2))',
+  sqlite : 'SELECT ("customer"."name" + "customer"."age") AS "nameAndAge" FROM "customer" WHERE (("customer"."age" > $1) AND ("customer"."age" < $2))',
+  mysql  : 'SELECT (`customer`.`name` + `customer`.`age`) AS `nameAndAge` FROM `customer` WHERE ((`customer`.`age` > ?) AND (`customer`.`age` < ?))',
+  params : [10, 20]
+});
+
+Harness.test({
+  query  : customer.select(customer.age.between(10, 20).as('ageBetween')),
+  pg     : 'SELECT ("customer"."age" BETWEEN $1 AND $2) AS "ageBetween" FROM "customer"',
+  sqlite : 'SELECT ("customer"."age" BETWEEN $1 AND $2) AS "ageBetween" FROM "customer"',
+  mysql  : 'SELECT (`customer`.`age` BETWEEN ? AND ?) AS `ageBetween` FROM `customer`',
+  params : [10, 20]
+});

--- a/test/function-tests.js
+++ b/test/function-tests.js
@@ -10,6 +10,13 @@ var user = sql.define({
 });
 
 suite('function', function() {
+  test('alias function call', function() {
+    var upper = sql.functions.UPPER;
+    var aliasedUpper = upper(user.email).as('upperAlias').toQuery();
+
+    assert.equal(aliasedUpper.text, 'UPPER("user"."email") AS "upperAlias"');
+  });
+
   test('creating function call works', function() {
     var upper = sql.functionCallCreator('UPPER');
     var functionCall = upper('hello', 'world').toQuery();


### PR DESCRIPTION
Unary, Binary, Ternary and FunctionCall nodes are aliasable using the AliasNode.

Column and Table already have their own built-in "as" aliasing, so that's left alone. Changing that to use the Alias node will probably break back compat.

The .as() alias shortcut is implemented as a Mixin inside Alias.js
