### PR TITLE
Column doesn't need to use delayed runtime valueExpressionMixin

### DIFF
--- a/lib/column.js
+++ b/lib/column.js
@@ -7,7 +7,6 @@ var OrderByColumnNode = require(__dirname + '/node/orderByColumn');
 var UnaryNode = require(__dirname + '/node/unary');
 var TextNode = require(__dirname + '/node/text');
 
-var valueExpressionMixed = false;
 var Column = function(config) {
   this.table = config.table;
   for(var name in config) {
@@ -20,14 +19,10 @@ var Column = function(config) {
     direction: new TextNode('DESC')
   });
   this.dataType = config.dataType;
-  // Delay mixin to runtime, when all nodes have been defined, and
-  // mixin only once.  This is to avoid circular dependency in
-  // CommonJS.
-  if (!valueExpressionMixed) {
-    valueExpressionMixed = true;
-    _.extend(Column.prototype, valueExpressionMixin());
-  }
 };
+
+// mix in value expression
+_.extend(Column.prototype, valueExpressionMixin());
 
 var contextify = function(base) {
   var context = Object.create(Column.prototype);


### PR DESCRIPTION
The delayed runtime value expression mixing is only necessary for unary, binary and ternary nodes.

All other nodes such as function call and column and get it mixed in immediately.
