### PR TITLE
optional travis build for node v0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
-  - 0.4
-  - 0.6
-  - 0.8
-  - 0.10
+  - "0.4"
+  - "0.6"
+  - "0.8"
+  - "0.10"
+  - "0.11"
+
+matrix:
+  allow_failures:
+    - node_js: "0.11"


### PR DESCRIPTION
start building and testing for nodejs 0.11, allow failures on 0.11
