### PR TITLE
Only test .js files in test/dialects

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,8 @@ directories.forEach(function (d) {
   /*jshint boss: true */
   for(var i = 0, file; file = files[i]; i++) {
     var filePath = path.join(d, file);
-    require(filePath);
+    if (path.extname(file) === '.js') {
+      require(filePath);
+    }
   }
 });


### PR DESCRIPTION
This pull request limits the files which are automatically required from the `test/dialect` directory to filenames which have a `.js` extension.

My primary motivation is to avoid calling `require` on Vim's swap files, which causes the tests to fail whenever Vim has a file open in the `test/dialect` directory.  Any alternative implementations which accomplish that goal would be fine with me.

Thanks!
