### PR TITLE
Unnecessary code in createIndex, dropIndex and indexes 

### DIFF
--- a/lib/node/createIndex.js
+++ b/lib/node/createIndex.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node   = require('./');
+var sliced = require('sliced');
 
 module.exports = Node.define({
   type: 'CREATE INDEX',
@@ -8,11 +9,8 @@ module.exports = Node.define({
   constructor: function(table, indexName) {
     Node.call(this);
 
-    this.table     = table;
-    this.names     = [];
-    this.columns   = [];
-    this.valueSets = [];
-    this.options   = { indexName: indexName, columns: [] };
+    this.table   = table;
+    this.options = { indexName: indexName, columns: [] };
   },
 
   unique: function() {
@@ -36,7 +34,7 @@ module.exports = Node.define({
   },
 
   on: function() {
-    var args = Array.prototype.slice.call(arguments);
+    var args = sliced(arguments);
     this.options.columns = this.options.columns.concat(args);
     return this;
   },

--- a/lib/node/dropIndex.js
+++ b/lib/node/dropIndex.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./');
 
 module.exports = Node.define({
   type: 'DROP INDEX',
 
   constructor: function(table, indexName) {
-    var args = Array.prototype.slice.call(arguments);
-
     if (!indexName) {
       throw new Error('No index defined!');
     } else if (Array.isArray(indexName) && (typeof indexName[0] === 'string')) {
@@ -19,11 +17,8 @@ module.exports = Node.define({
 
     Node.call(this);
 
-    this.table     = table;
-    this.names     = [];
-    this.columns   = [];
-    this.valueSets = [];
-    this.options   = { indexName: indexName };
+    this.table   = table;
+    this.options = { indexName: indexName };
   },
 
   indexName: function() {

--- a/lib/node/indexes.js
+++ b/lib/node/indexes.js
@@ -1,15 +1,12 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./');
 var IndexesNode = module.exports = Node.define({
   type: 'INDEXES',
 
   constructor: function(table) {
     Node.call(this);
 
-    this.table     = table;
-    this.names     = [];
-    this.columns   = [];
-    this.valueSets = [];
+    this.table = table;
   }
 });

--- a/lib/node/insert.js
+++ b/lib/node/insert.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var Node = require(__dirname);
+var DefaultNode   = require('./default');
+var Node          = require('./');
 var ParameterNode = require('./parameter');
-var DefaultNode = require('./default');
 
 var Insert = Node.define({
   type: 'INSERT',
@@ -34,7 +34,7 @@ Insert.prototype.add = function (nodes) {
 };
 
 /*
- * Get paramters for all values to be inserted. This function
+ * Get parameters for all values to be inserted. This function
  * handles handles bulk inserts, where keys may be present
  * in some objects and not others. When keys are not present,
  * the insert should refer to the column value as DEFAULT.


### PR DESCRIPTION
I don't think these are necessary. I could not find any code that uses the names, columns, or valuesets attributes of these particular nodes. The constructor looks awfully similar to the Insert node constructor, so I suspect this was a the result of a copy paste.

Please review this change carefully. If these attributes are in fact useful, then we need to add tests for them.
