### PR TITLE
Provide mechanism for SELECTing literal values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,13 @@
 'use strict';
 
-var _            = require('lodash');
-var FunctionCall = require('./node/functionCall');
-var functions    = require('./functions');
-var getDialect   = require('./dialect');
-var Query        = require('./node/query');
-var sliced       = require('sliced');
-var Table        = require('./table');
+var _             = require('lodash');
+var FunctionCall  = require('./node/functionCall');
+var functions     = require('./functions');
+var getDialect    = require('./dialect');
+var ParameterNode = require('./node/parameter');
+var Query         = require('./node/query');
+var sliced        = require('sliced');
+var Table         = require('./table');
 
 // default dialect is postgres
 var DEFAULT_DIALECT = 'postgres';
@@ -50,6 +51,11 @@ Sql.prototype.select = function() {
 Sql.prototype.setDialect = function(dialect) {
   this.dialect = getDialect(dialect);
   return this;
+};
+
+// Wrap a literal value (for use in SELECT)
+Sql.prototype.value = function(value) {
+  return new ParameterNode(value);
 };
 
 // back compat shim for the Sql class constructor

--- a/test/dialects/select-tests.js
+++ b/test/dialects/select-tests.js
@@ -2,6 +2,7 @@
 
 var Harness = require('./support');
 var post = Harness.definePostTable();
+var sql = require('../../lib');
 
 Harness.test({
   query: post.select(post.id).select(post.content),
@@ -18,4 +19,21 @@ Harness.test({
     string: 'SELECT `post`.`id`, `post`.`content` FROM `post`'
   },
   params: []
+});
+
+Harness.test({
+  query: post.select(post.id).select(post.content).select(sql.value(4)),
+  pg: {
+    text  : 'SELECT "post"."id", "post"."content", $1 FROM "post"',
+    string: 'SELECT "post"."id", "post"."content", 4 FROM "post"'
+  },
+  sqlite: {
+    text  : 'SELECT "post"."id", "post"."content", $1 FROM "post"',
+    string: 'SELECT "post"."id", "post"."content", 4 FROM "post"'
+  },
+  mysql: {
+    text  : 'SELECT `post`.`id`, `post`.`content`, ? FROM `post`',
+    string: 'SELECT `post`.`id`, `post`.`content`, 4 FROM `post`'
+  },
+  params: [4]
 });


### PR DESCRIPTION
**Reviewer Note:**  I'm not attached to the name `.value()` or the placement on the `Sql` object.  This pull request is more about opening discussion for how to support SELECTing literal values in some way.  Personally, I'd probably treat non-node values passed to `.select()` as literal values so users don't accidentally shoot themselves in the foot, but since it is used in many places I realize it is probably an unreasonable change at this point.

Previously, the API did not provide a way to include a literal value in
a SELECT statement.  Although users could include an un-escaped string
in the generated statement, this would require users to perform their
own value quoting and escaping.  Although there was previously not much
use for literal values in SELECT, it is not an uncommon use when the
SELECT is part of an INSERT statement.

Add a .value() method to the Sql object which allows users to create
ParameterNodes for values.  Users can then pass the result to .select()
to get literal values in their SELECT statements safely.

Add a test for this use case.

Signed-off-by: Kevin Locke <klocke@quantpost.com>