### PR TITLE
making primary key work inside create

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -490,6 +490,11 @@ Postgres.prototype.visitColumn = function(columnNode) {
     assert(columnNode.dataType, 'dataType missing for column ' + columnNode.name +
       ' (CREATE TABLE and ADD COLUMN statements require a dataType)');
     txt += ' ' + columnNode.dataType;
+
+    if (this._visitingCreate && columnNode.primaryKey) {
+      // creating a column as a primary key
+      txt += ' PRIMARY KEY';
+    }
   }
   return [txt];
 };

--- a/lib/node/column.js
+++ b/lib/node/column.js
@@ -15,6 +15,7 @@ module.exports = Node.define({
     this.value = config.getValue();
     this.dataType = config.dataType;
     this.distinct = config.distinct;
+    this.primaryKey = config.primaryKey;
   },
   as: function(alias) {
     this.alias = alias;

--- a/test/dialects/create-table-tests.js
+++ b/test/dialects/create-table-tests.js
@@ -121,3 +121,26 @@ Harness.test({
     string: 'CREATE TABLE `user` (`id` varchar(100)) ENGINE=MyISAM DEFAULT CHARSET=latin1'
   }
 });
+
+Harness.test({
+  query: Table.define({
+    name: 'user',
+    columns: [{
+      name: 'id',
+      dataType: 'int',
+      primaryKey: true
+    }]
+  }).create(),
+  pg: {
+    text  : 'CREATE TABLE "user" ("id" int PRIMARY KEY)',
+    string: 'CREATE TABLE "user" ("id" int PRIMARY KEY)'
+  },
+  sqlite: {
+    text  : 'CREATE TABLE "user" ("id" int PRIMARY KEY)',
+    string: 'CREATE TABLE "user" ("id" int PRIMARY KEY)'
+  },
+  mysql: {
+    text  : 'CREATE TABLE `user` (`id` int PRIMARY KEY)',
+    string: 'CREATE TABLE `user` (`id` int PRIMARY KEY)'
+  }
+});


### PR DESCRIPTION
column node's primaryKey attribute is only used during autojoin, this makes the attribute output the correct SQL on create()
