### PR TITLE
Allow qualified column names w/ aggregate functions

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -463,10 +463,10 @@ Postgres.prototype.visitColumn = function(columnNode) {
   }
   if(!this._visitedInsert && !this._visitingUpdateTargetColumn && !this._visitingCreate && !this._visitingAlter) {
     if(table.alias) {
-      txt = this.quote(table.alias);
+      txt += this.quote(table.alias);
     } else {
       if(table.getSchema()) {
-        txt = this.quote(table.getSchema());
+        txt += this.quote(table.getSchema());
         txt += '.';
       }
       txt += this.quote(table.getName());


### PR DESCRIPTION
I bumped into a problem when attempting to generate something like COUNT('tablename'.'column').
