### PR TITLE
added 'prefix' option to Table.prototype.star()

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -121,7 +121,14 @@ Table.prototype.getName = function() {
   return this._name;
 };
 
-Table.prototype.star = function() {
+Table.prototype.star = function(options) {
+  options = options || {};
+  if (options.prefix) {
+    return this.columns.map(function(column) {
+      return this[column.name].as(options.prefix + column.name);
+    }.bind(this));
+  }
+
   return new Column({table: this, star: true});
 };
 

--- a/test/dialects/table-tests.js
+++ b/test/dialects/table-tests.js
@@ -55,6 +55,23 @@ Harness.test({
 });
 
 Harness.test({
+  query: user.select(user.star({ prefix: 'foo_' })).from(user),
+  pg: {
+    text: 'SELECT "user"."id" AS "foo_id", "user"."name" AS "foo_name" FROM "user"',
+    string: 'SELECT "user"."id" AS "foo_id", "user"."name" AS "foo_name" FROM "user"'
+  },
+  sqlite: {
+    text: 'SELECT "user"."id" AS "foo_id", "user"."name" AS "foo_name" FROM "user"',
+    string: 'SELECT "user"."id" AS "foo_id", "user"."name" AS "foo_name" FROM "user"'
+  },
+  mysql: {
+    text: 'SELECT `user`.`id` AS `foo_id`, `user`.`name` AS `foo_name` FROM `user`',
+    string: 'SELECT `user`.`id` AS `foo_id`, `user`.`name` AS `foo_name` FROM `user`'
+  },
+  params: []
+});
+
+Harness.test({
   query: user.select(user.id).from(user).where(user.name.equals('foo')),
   pg: {
     text  : 'SELECT "user"."id" FROM "user" WHERE ("user"."name" = $1)',


### PR DESCRIPTION
Added a prefix option to `star()`, e.g. `user.star({ prefix: 'user_' })`.

Example,

``` javascript
var query = user.select(user.star(), userInfo.star({ prefix: 'info_' }))
  .from(user.join(userInfo).on(userInfo.userId.equals(user.id)));
```

From this query you would get the following fields in the result:

```
| id | name | email | info_id | info_address | info_phone |
```

Basically, it makes it the query much less verbose when you want everything from multiple tables and their column names potentially conflict. You won't have to spell everything out.
