### PR TITLE
include namespace in index query

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -792,14 +792,16 @@ Postgres.prototype.visitModifier = function(node) {
 
 Postgres.prototype.visitIndexes = function(node) {
   /* jshint unused: false */
-  var tableName = this.visit(this._queryNode.table.toNode())[0];
+  var tableName = this._queryNode.table.getName();
+  var schemaName = this._queryNode.table.getSchema() || "public";
 
   return [
     "SELECT relname",
     "FROM pg_class",
     "WHERE oid IN (",
     "SELECT indexrelid",
-    "FROM pg_index, pg_class WHERE pg_class.relname=" + tableName.replace(/"/g, "'"),
+    "FROM pg_index, pg_class WHERE pg_class.relname='" + tableName + "'",
+    "AND pg_class.relnamespace IN (SELECT pg_namespace.oid FROM pg_namespace WHERE nspname = '" + schemaName + "')",
     "AND pg_class.oid=pg_index.indrelid)"
   ].join(' ');
 };


### PR DESCRIPTION
then namespace is included in the index query now.  
tables with schema names resulted in invalid sql.  
