### PR TITLE
index select including namespace - with test

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -792,14 +792,16 @@ Postgres.prototype.visitModifier = function(node) {
 
 Postgres.prototype.visitIndexes = function(node) {
   /* jshint unused: false */
-  var tableName = this.visit(this._queryNode.table.toNode())[0];
+  var tableName = this._queryNode.table.getName();
+  var schemaName = this._queryNode.table.getSchema() || "public";
 
   return [
     "SELECT relname",
     "FROM pg_class",
     "WHERE oid IN (",
     "SELECT indexrelid",
-    "FROM pg_index, pg_class WHERE pg_class.relname=" + tableName.replace(/"/g, "'"),
+    "FROM pg_index, pg_class WHERE pg_class.relname='" + tableName + "'",
+    "AND pg_class.relnamespace IN (SELECT pg_namespace.oid FROM pg_namespace WHERE nspname = '" + schemaName + "')",
     "AND pg_class.oid=pg_index.indrelid)"
   ].join(' ');
 };

--- a/test/dialects/indexes-tests.js
+++ b/test/dialects/indexes-tests.js
@@ -6,8 +6,8 @@ var post = Harness.definePostTable();
 Harness.test({
   query: post.indexes(),
   pg: {
-    text  : 'SELECT relname FROM pg_class WHERE oid IN ( SELECT indexrelid FROM pg_index, pg_class WHERE pg_class.relname=\'post\' AND pg_class.oid=pg_index.indrelid)',
-    string: 'SELECT relname FROM pg_class WHERE oid IN ( SELECT indexrelid FROM pg_index, pg_class WHERE pg_class.relname=\'post\' AND pg_class.oid=pg_index.indrelid)'
+    text  : 'SELECT relname FROM pg_class WHERE oid IN ( SELECT indexrelid FROM pg_index, pg_class WHERE pg_class.relname=\'post\' AND pg_class.relnamespace IN (SELECT pg_namespace.oid FROM pg_namespace WHERE nspname = \'public\') AND pg_class.oid=pg_index.indrelid)',
+    string: 'SELECT relname FROM pg_class WHERE oid IN ( SELECT indexrelid FROM pg_index, pg_class WHERE pg_class.relname=\'post\' AND pg_class.relnamespace IN (SELECT pg_namespace.oid FROM pg_namespace WHERE nspname = \'public\') AND pg_class.oid=pg_index.indrelid)'
   },
   mysql: {
     text  : 'SHOW INDEX FROM `post`',


### PR DESCRIPTION
the index select ignored schema. when a schema was defined a syntax error sql was generated. if several tables with the same name but different schema exist the sql was ambiguous.
this pr replaces https://github.com/brianc/node-sql/pull/191
it includes modifications to the test which hopefully will run through now.
