### PR TITLE
Add support for compound primary keys

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -246,7 +246,20 @@ Postgres.prototype.visitCreate = function(create) {
   var result = ['CREATE TABLE'];
   result = result.concat(create.nodes.map(this.visit.bind(this)));
   result.push(this.visit(table.toNode()));
-  result.push('(' + col_nodes.map(this.visit.bind(this)).join(', ') + ')');
+  this._visitCreateCompoundPrimaryKey = col_nodes.filter(function(n) {
+    return n.primaryKey;
+  }).length > 1;
+  var colspec = '(' + col_nodes.map(this.visit.bind(this)).join(', ');
+  if (this._visitCreateCompoundPrimaryKey) {
+    colspec += ', PRIMARY KEY (';
+    colspec += col_nodes.map(function(node) {
+      return this.quote(node.name);
+    }.bind(this)).join(', ');
+    colspec += ')';
+  }
+  colspec += ')';
+  result.push(colspec);
+  this._visitCreateCompoundPrimaryKey = false;
   this._visitingCreate = false;
   return result;
 };
@@ -663,7 +676,7 @@ Postgres.prototype.visitColumn = function(columnNode) {
     txt.push(' ' + columnNode.dataType);
 
     if (this._visitingCreate) {
-      if (columnNode.primaryKey) {
+      if (columnNode.primaryKey && !this._visitCreateCompoundPrimaryKey) {
         // creating a column as a primary key
         txt.push(' PRIMARY KEY');
       } else if (columnNode.notNull) {

--- a/test/dialects/create-table-tests.js
+++ b/test/dialects/create-table-tests.js
@@ -273,3 +273,25 @@ Harness.test({
   },
   params: []
 });
+
+Harness.test({
+  query: Table.define({
+    name: 'membership',
+    columns: {
+      group_id: { dataType: 'int', primaryKey: true},
+      user_id:  { dataType: 'int', primaryKey: true},
+    }
+  }).create(),
+  pg: {
+    text  : 'CREATE TABLE "membership" ("group_id" int, "user_id" int, PRIMARY KEY ("group_id", "user_id"))',
+    string: 'CREATE TABLE "membership" ("group_id" int, "user_id" int, PRIMARY KEY ("group_id", "user_id"))',
+  },
+  sqlite: {
+    text  : 'CREATE TABLE "membership" ("group_id" int, "user_id" int, PRIMARY KEY ("group_id", "user_id"))',
+    string: 'CREATE TABLE "membership" ("group_id" int, "user_id" int, PRIMARY KEY ("group_id", "user_id"))',
+  },
+  mysql: {
+    text  : 'CREATE TABLE `membership` (`group_id` int, `user_id` int, PRIMARY KEY (`group_id`, `user_id`))',
+    string: 'CREATE TABLE `membership` (`group_id` int, `user_id` int, PRIMARY KEY (`group_id`, `user_id`))',
+  }
+});


### PR DESCRIPTION
This patch adds support for compound primary keys. If multiple columns
are specified with `primaryKey: true`, the generated table create query
will contain a separate `PRIMARY KEY` section
