### PR TITLE
drop index fix for pg

### DIFF
--- a/lib/dialect/mysql.js
+++ b/lib/dialect/mysql.js
@@ -76,4 +76,17 @@ Mysql.prototype.visitIndexes = function(node) {
   return "SHOW INDEX FROM " + tableName;
 };
 
+// literaly a copy from the old Postgres version
+// i dont know if it makes sense
+// pls test on a actual mysql db
+Mysql.prototype.visitDropIndex = function(node) {
+  var result = [ 'DROP INDEX' ];
+
+  result.push(this.quote(node.options.indexName));
+  result.push("ON");
+  result.push(this.visit(node.table.toNode()));
+
+  return result;
+};
+
 module.exports = Mysql;

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -856,9 +856,7 @@ Postgres.prototype.visitCreateIndex = function(node) {
 Postgres.prototype.visitDropIndex = function(node) {
   var result = [ 'DROP INDEX' ];
 
-  result.push(this.quote(node.options.indexName));
-  result.push("ON");
-  result.push(this.visit(node.table.toNode()));
+  result.push(this.quote(node.table.getSchema() || "public") + "." + this.quote(node.options.indexName));
 
   return result;
 };

--- a/lib/dialect/sqlite.js
+++ b/lib/dialect/sqlite.js
@@ -70,4 +70,18 @@ Sqlite.prototype.visitRestrict = function() {
   throw new Error('Sqlite do not support RESTRICT in DROP TABLE');
 };
 
+// literaly a copy from the old Postgres version
+// i dont know if it makes sense
+// pls test on a actual sqlite db
+Sqlite.prototype.visitDropIndex = function(node) {
+  var result = [ 'DROP INDEX' ];
+
+  result.push(this.quote(node.options.indexName));
+  result.push("ON");
+  result.push(this.visit(node.table.toNode()));
+
+  return result;
+};
+
+
 module.exports = Sqlite;

--- a/test/dialects/indexes-tests.js
+++ b/test/dialects/indexes-tests.js
@@ -124,8 +124,8 @@ Harness.test({
 Harness.test({
   query: post.indexes().drop('index_name'),
   pg: {
-    text  : 'DROP INDEX "index_name" ON "post"',
-    string: 'DROP INDEX "index_name" ON "post"'
+    text  : 'DROP INDEX "public"."index_name"',
+    string: 'DROP INDEX "public"."index_name"'
   },
   mysql: {
     text  : 'DROP INDEX `index_name` ON `post`',
@@ -141,8 +141,8 @@ Harness.test({
 Harness.test({
   query: post.indexes().drop(post.userId, post.id),
   pg: {
-    text  : 'DROP INDEX "post_id_userId" ON "post"',
-    string: 'DROP INDEX "post_id_userId" ON "post"'
+    text  : 'DROP INDEX "public"."post_id_userId"',
+    string: 'DROP INDEX "public"."post_id_userId"'
   },
   mysql: {
     text  : 'DROP INDEX `post_id_userId` ON `post`',


### PR DESCRIPTION
drop index resulted in a sql syntax error on pg.

i also added the option to address indexes in different schemas.

see pg docu DROP INDEX:
http://www.postgresql.org/docs/9.2/static/sql-dropindex.html

