### PR TITLE
Add method table.clone([config])

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -146,7 +146,7 @@ Table.prototype.star = function(options) {
 
 Table.prototype.literal = function(literal) {
   return new LiteralNode(literal);
-}
+};
 
 Table.prototype.count = function(alias) {
   var name = this.alias || this._name,
@@ -177,9 +177,9 @@ Table.prototype.subQuery = function(alias) {
   var query = new Query(this);
   query.type = 'SUBQUERY';
   query.alias = alias;
-	query.join = function(other) {
-		return new JoinNode('INNER', this.toNode(), other.toNode(), other);
-	}
+  query.join = function(other) {
+    return new JoinNode('INNER', this.toNode(), other.toNode(), other);
+  };
   return query;
 };
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -47,6 +47,17 @@ Table.define = function(config) {
   return table;
 };
 
+Table.prototype.clone = function(config) {
+  return Table.define(lodash.extend({
+    schema: this._schema,
+    name: this._name,
+    sql: this.sql,
+    columnWhiteList: !!this.columnWhiteList,
+    snakeToCamel: !!this.snakeToCamel,
+    columns: this.columns
+  }, config || {}));
+};
+
 Table.prototype.createColumn = function(col) {
   if(!(col instanceof Column)) {
     if(typeof col === 'string') {

--- a/test/table-tests.js
+++ b/test/table-tests.js
@@ -187,6 +187,40 @@ test('set and get schema', function () {
   assert.equal(table.getSchema(), 'barbarz');
 });
 
+suite('table.clone', function() {
+  test('check if it is a copy, not just a reference', function() {
+    var table = Table.define({ name: 'foo', columns: [] });
+    var copy = table.clone();
+    assert.notEqual(table, copy);
+  });
+
+  test('copy columns', function() {
+    var table = Table.define({ name: 'foo', columns: ['bar'] });
+    var copy = table.clone();
+    assert(copy.get('bar') instanceof Column);
+  });
+
+  test('overwrite config while copying', function() {
+    var table = Table.define({
+      name: 'foo',
+      schema: 'foobar',
+      columns: ['bar'],
+      snakeToCamel: true,
+      columnWhiteList: true
+    });
+
+    var copy = table.clone({
+      schema: 'test',
+      snakeToCamel: false,
+      columnWhiteList: false
+    });
+
+    assert.equal(copy.getSchema(), 'test');
+    assert.equal(copy.snakeToCamel, false);
+    assert.equal(copy.columnWhiteList, false);
+  });
+});
+
 test('dialects', function () {
   var sql = new Sql.Sql('mysql');
   var foo = sql.define({ name: 'foo', columns: [ 'id' ] }),


### PR DESCRIPTION
Our application makes heavy use of schemas and we needed a way to clone tables. So this is a quick stab at it, but someone who is familiar with the projects codebase should look over it. 

Also fixes half of #198 I think.