### PR TITLE
support empty array where clause

### DIFF
--- a/lib/node/where.js
+++ b/lib/node/where.js
@@ -12,13 +12,17 @@ var normalizeNode = function(table, node) {
   else if (Array.isArray(node)) {
     result = false;
 
-    node.forEach(function (subNode) {
-      if (!result) {
-        result = subNode;
-      } else {
-        result = result.and(subNode);
-      }
-    });
+    if (node.length === 0) {
+      result = new TextNode('(1 = 1)');
+    } else {
+      node.forEach(function (subNode) {
+        if (!result) {
+          result = subNode;
+        } else {
+          result = result.and(subNode);
+        }
+      });
+    }
   }
   else if (!node.toNode && typeof node === 'object'){
     result = false;

--- a/test/dialects/where-clause-tests.js
+++ b/test/dialects/where-clause-tests.js
@@ -53,3 +53,20 @@ Harness.test({
   },
   params: []
 });
+
+Harness.test({
+  query: user.where([]),
+  pg: {
+    text  : 'SELECT * FROM "user" WHERE (1 = 1)',
+    string: 'SELECT * FROM "user" WHERE (1 = 1)'
+  },
+  mysql: {
+    text  : 'SELECT * FROM `user` WHERE (1 = 1)',
+    string: 'SELECT * FROM `user` WHERE (1 = 1)'
+  },
+  sqlite: {
+    text  : 'SELECT * FROM "user" WHERE (1 = 1)',
+    string: 'SELECT * FROM "user" WHERE (1 = 1)'
+  },
+  params: []
+});


### PR DESCRIPTION
If the where clause is created dynamically it could be the case that it's empty. With this patch a dummy clause (1 = 1) is created in that case to avoid errors.