### PR TITLE
fixed missing table name for .star() with alias case

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -650,14 +650,20 @@ Postgres.prototype.visitColumn = function(columnNode) {
     var allCols = [];
     var hasAliases = false;
     if(columnNode.aggregator !== 'COUNT') {
+      var tableName = txt.join('');
       for (var i = 0; i < table.columns.length; ++i) {
         var col = table.columns[i];
         var aliased = col.name !== (col.alias || col.property);
         hasAliases = hasAliases || aliased;
-        allCols.push(this.quote(col.name) + (aliased ? ' AS ' + this.quote(col.alias || col.property) : ''));
+        allCols.push(tableName + this.quote(col.name) + (aliased ? ' AS ' + this.quote(col.alias || col.property) : ''));
       }
     }
-    txt.push(hasAliases ? allCols.join(', ') : '*');
+    if(hasAliases) {
+      txt = [allCols.join(', ')];
+    }
+    else {
+      txt.push('*');
+    }
   }
   else {
     txt.push(this.quote(columnNode.name));

--- a/test/dialects/select-tests.js
+++ b/test/dialects/select-tests.js
@@ -2,6 +2,7 @@
 
 var Harness = require('./support');
 var post = Harness.definePostTable();
+var customerAlias = Harness.defineCustomerAliasTable();
 
 Harness.test({
   query: post.select(post.id).select(post.content),
@@ -16,6 +17,23 @@ Harness.test({
   mysql: {
     text  : 'SELECT `post`.`id`, `post`.`content` FROM `post`',
     string: 'SELECT `post`.`id`, `post`.`content` FROM `post`'
+  },
+  params: []
+});
+
+Harness.test({
+  query: customerAlias.select(customerAlias.star()),
+  pg: {
+    text  : 'SELECT "customer"."id" AS "id_alias", "customer"."name" AS "name_alias", "customer"."age" AS "age_alias", "customer"."income" AS "income_alias", "customer"."metadata" AS "metadata_alias" FROM "customer"',
+    string: 'SELECT "customer"."id" AS "id_alias", "customer"."name" AS "name_alias", "customer"."age" AS "age_alias", "customer"."income" AS "income_alias", "customer"."metadata" AS "metadata_alias" FROM "customer"'
+  },
+  sqlite: {
+    text  : 'SELECT "customer"."id" AS "id_alias", "customer"."name" AS "name_alias", "customer"."age" AS "age_alias", "customer"."income" AS "income_alias", "customer"."metadata" AS "metadata_alias" FROM "customer"',
+    string: 'SELECT "customer"."id" AS "id_alias", "customer"."name" AS "name_alias", "customer"."age" AS "age_alias", "customer"."income" AS "income_alias", "customer"."metadata" AS "metadata_alias" FROM "customer"'
+  },
+  mysql: {
+    text :  'SELECT `customer`.`id` AS `id_alias`, `customer`.`name` AS `name_alias`, `customer`.`age` AS `age_alias`, `customer`.`income` AS `income_alias`, `customer`.`metadata` AS `metadata_alias` FROM `customer`',
+    string: 'SELECT `customer`.`id` AS `id_alias`, `customer`.`name` AS `name_alias`, `customer`.`age` AS `age_alias`, `customer`.`income` AS `income_alias`, `customer`.`metadata` AS `metadata_alias` FROM `customer`'
   },
   params: []
 });


### PR DESCRIPTION
If .start() is used with a table definition that contains aliases, only the first column contains the table/schema name. This patch adds the table/schema prefix to all columns.