### PR TITLE
Harmless select in case of invalid insert attempt

### DIFF
--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -180,9 +180,6 @@ var Query = Node.define({
     var self = this;
 
     var args = sliced(arguments);
-    if (o.length == 0) {
-      o = {};
-    }
     // object literal
     if (arguments.length === 1 && !o.toNode && !o.forEach) {
       args = [];

--- a/lib/table.js
+++ b/lib/table.js
@@ -174,7 +174,12 @@ Table.prototype.subQuery = function(alias) {
 
 Table.prototype.insert = function() {
   var query = new Query(this);
-  query.insert.apply(query, arguments);
+  if(arguments[0].length == 0){
+    query.select.call(query, this.star());
+    query.where.apply(query,["1=2"]);
+  } else {
+    query.insert.apply(query, arguments);
+  }
   return query;
 };
 

--- a/test/dialects/insert-tests.js
+++ b/test/dialects/insert-tests.js
@@ -409,8 +409,8 @@ Harness.test({
   query: post.insert([]),
 
   mysql: {
-    text  : 'INSERT INTO `post` () VALUES ()',
-    string: 'INSERT INTO `post` () VALUES ()'
+    text  : 'SELECT `post`.* FROM `post` WHERE (1=2)',
+    string: 'SELECT `post`.* FROM `post` WHERE (1=2)'
   },
   params: []
 });


### PR DESCRIPTION
Regarding  https://github.com/brianc/node-sql/pull/197, As suggested by @spion This patch will override previous fix and will return with harmless select statement with "WHERE (1=2)"