### PR TITLE
Microsoft SQL Server CASE Statement Updates

### DIFF
--- a/lib/dialect/mssql.js
+++ b/lib/dialect/mssql.js
@@ -113,6 +113,42 @@ Mssql.prototype.visitAlter = function(alter) {
   return Mssql.super_.prototype.visitAlter.call(this, alter);
 };
 
+// Need to implement a special version of CASE since SQL doesn't support
+//   CASE WHEN true THEN xxx END
+//   the "true" has to be a boolean expression like 1=1
+Mssql.prototype.visitCase = function(caseExp) {
+  var _this=this
+
+  function _whenValue(node){
+    if (node.type!='PARAMETER') return _this.visit(node);
+    // dealing with a true/false value
+    var val=node.value();
+    if (val==true) return '1=1'; else return '0=1';
+  }
+
+  assert(caseExp.whenList.length == caseExp.thenList.length);
+
+  var self = this;
+  var text = '(CASE';
+
+  this.visitingCase = true;
+
+  for (var i = 0; i < caseExp.whenList.length; i++) {
+    var whenExp = ' WHEN ' + _whenValue(caseExp.whenList[i]);
+    var thenExp = ' THEN ' + this.visit(caseExp.thenList[i]);
+    text += whenExp + thenExp;
+  }
+
+  if (null != caseExp.else && undefined != caseExp.else) {
+    text += ' ELSE ' + this.visit(caseExp.else);
+  }
+
+  this.visitingCase = false;
+
+  text += ' END)';
+  return [text];
+}
+
 Mssql.prototype.visitColumn = function(columnNode) {
   var self=this;
   var table;

--- a/test/dialects/case-tests.js
+++ b/test/dialects/case-tests.js
@@ -19,8 +19,9 @@ Harness.test({
     string: 'SELECT (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE 2 END) FROM `customer`'
   },
   mssql: {
-    text  : 'SELECT (CASE WHEN @1 THEN @2 WHEN @3 THEN @4 ELSE @5 END) FROM [customer]',
-    string: 'SELECT (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE 2 END) FROM [customer]'
+    text  : 'SELECT (CASE WHEN 1=1 THEN @1 WHEN 0=1 THEN @2 ELSE @3 END) FROM [customer]',
+    string: 'SELECT (CASE WHEN 1=1 THEN 0 WHEN 0=1 THEN 1 ELSE 2 END) FROM [customer]',
+    params: [0, 1, 2]
   },
   params: [true, 0, false, 1, 2]
 });
@@ -41,8 +42,9 @@ Harness.test({
     string: 'SELECT (`customer`.`age` + (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE 2 END)) FROM `customer`'
   },
   mssql: {
-    text  : 'SELECT ([customer].[age] + (CASE WHEN @1 THEN @2 WHEN @3 THEN @4 ELSE @5 END)) FROM [customer]',
-    string: 'SELECT ([customer].[age] + (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE 2 END)) FROM [customer]'
+    text  : 'SELECT ([customer].[age] + (CASE WHEN 1=1 THEN @1 WHEN 0=1 THEN @2 ELSE @3 END)) FROM [customer]',
+    string: 'SELECT ([customer].[age] + (CASE WHEN 1=1 THEN 0 WHEN 0=1 THEN 1 ELSE 2 END)) FROM [customer]',
+    params: [0, 1, 2]
   },
   params: [true, 0, false, 1, 2]
 });
@@ -63,8 +65,9 @@ Harness.test({
     string: 'SELECT ((CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE 2 END) + 3) FROM `customer`'
   },
   mssql: {
-    text  : 'SELECT ((CASE WHEN @1 THEN @2 WHEN @3 THEN @4 ELSE @5 END) + @6) FROM [customer]',
-    string: 'SELECT ((CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE 2 END) + 3) FROM [customer]'
+    text  : 'SELECT ((CASE WHEN 1=1 THEN @1 WHEN 0=1 THEN @2 ELSE @3 END) + @4) FROM [customer]',
+    string: 'SELECT ((CASE WHEN 1=1 THEN 0 WHEN 0=1 THEN 1 ELSE 2 END) + 3) FROM [customer]',
+    params: [0, 1, 2, 3]
   },
   params: [true, 0, false, 1, 2, 3]
 });
@@ -85,8 +88,9 @@ Harness.test({
     string: 'SELECT (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE (`customer`.`age` BETWEEN 10 AND 20) END) FROM `customer`'
   },
   mssql: {
-    text  : 'SELECT (CASE WHEN @1 THEN @2 WHEN @3 THEN @4 ELSE ([customer].[age] BETWEEN @5 AND @6) END) FROM [customer]',
-    string: 'SELECT (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE ([customer].[age] BETWEEN 10 AND 20) END) FROM [customer]'
+    text  : 'SELECT (CASE WHEN 1=1 THEN @1 WHEN 0=1 THEN @2 ELSE ([customer].[age] BETWEEN @3 AND @4) END) FROM [customer]',
+    string: 'SELECT (CASE WHEN 1=1 THEN 0 WHEN 0=1 THEN 1 ELSE ([customer].[age] BETWEEN 10 AND 20) END) FROM [customer]',
+    params: [0, 1, 10, 20]
   },
   params: [true, 0, false, 1, 10, 20]
 });
@@ -107,8 +111,9 @@ Harness.test({
     string: 'SELECT (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 END) FROM `customer`'
   },
   mssql: {
-    text  : 'SELECT (CASE WHEN @1 THEN @2 WHEN @3 THEN @4 END) FROM [customer]',
-    string: 'SELECT (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 END) FROM [customer]'
+    text  : 'SELECT (CASE WHEN 1=1 THEN @1 WHEN 0=1 THEN @2 END) FROM [customer]',
+    string: 'SELECT (CASE WHEN 1=1 THEN 0 WHEN 0=1 THEN 1 END) FROM [customer]',
+    params: [0, 1]
   },
   params: [true, 0, false, 1]
 });


### PR DESCRIPTION
There was an issue with the implementation of a simple case statement in SQL Server. This syntax
```sql
SELECT CASE WHEN true THEN 1 END FROM xxx
```
is not supported in SQL Server. Not only is `true` not a valid keyword, but you have to use an actual expression like `1=1` (you can't just say WHEN 0, for example).

I've modified the code to output `1=1` for true values and `0=1` for false values.

I've updated the tests to reflect the new changes.