### PR TITLE
add match operator for text search

### DIFF
--- a/lib/dialect/mssql.js
+++ b/lib/dialect/mssql.js
@@ -26,6 +26,14 @@ Mssql.prototype._getParameterPlaceholder = function(index, value) {
 };
 
 Mssql.prototype.visitBinary = function(binary) {
+  if(binary.operator === '@@'){
+    var self = this;
+    var text = '(CONTAINS (' + this.visit(binary.left) + ', ';
+    text += this.visit(binary.right);
+    text += '))';
+    return [text];
+  }
+
   if (!isRightSideArray(binary)){
     return Mssql.super_.prototype.visitBinary.call(this, binary);
   }

--- a/lib/dialect/mysql.js
+++ b/lib/dialect/mysql.js
@@ -76,4 +76,15 @@ Mysql.prototype.visitIndexes = function(node) {
   return "SHOW INDEX FROM " + tableName;
 };
 
+Mysql.prototype.visitBinary = function(binary) {
+  if (binary.operator === '@@') {
+    var self = this;
+    var text = '(MATCH ' + this.visit(binary.left) + ' AGAINST ';
+    text += this.visit(binary.right);
+    text += ')';
+    return [text];
+  }
+  return Mysql.super_.prototype.visitBinary.call(this, binary);
+}
+
 module.exports = Mysql;

--- a/lib/dialect/sqlite.js
+++ b/lib/dialect/sqlite.js
@@ -70,4 +70,14 @@ Sqlite.prototype.visitRestrict = function() {
   throw new Error('Sqlite do not support RESTRICT in DROP TABLE');
 };
 
+Sqlite.prototype.visitBinary = function(binary) {
+  if(binary.operator === '@@'){
+    binary.operator = 'MATCH';
+    var ret = Sqlite.super_.prototype.visitBinary.call(this, binary);
+    binary.operator = '@@';
+    return ret;
+  }
+  return Sqlite.super_.prototype.visitBinary.call(this, binary);
+}
+
 module.exports = Sqlite;

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -50,7 +50,10 @@ var scalarFunctions = [
 // hstore function available to Postgres
 var hstoreFunction = 'HSTORE';
 
-var standardFunctionNames = aggregateFunctions.concat(scalarFunctions).concat(hstoreFunction);
+//text search functions available to Postgres
+var textsearchFunctions = ['TS_RANK','TS_RANK_CD', 'PLAINTO_TSQUERY', 'TO_TSQUERY', 'TO_TSVECTOR', 'SETWEIGHT'];
+
+var standardFunctionNames = aggregateFunctions.concat(scalarFunctions).concat(hstoreFunction).concat(textsearchFunctions);
 
 // creates a hash of standard functions for a sql instance
 var getStandardFunctions = function(sql) {

--- a/lib/node/valueExpression.js
+++ b/lib/node/valueExpression.js
@@ -150,6 +150,7 @@ var ValueExpressionMixin = function() {
     notLike    : binaryMethod('NOT LIKE'),
     ilike       : binaryMethod('ILIKE'),
     notIlike    : binaryMethod('NOT ILIKE'),
+    match      : binaryMethod('@@'),
     in         : inMethod,
     notIn      : notInMethod,
     between    : ternaryMethod('BETWEEN', 'AND'),

--- a/test/binary-clause-tests.js
+++ b/test/binary-clause-tests.js
@@ -38,4 +38,5 @@ test('operators', function() {
   assert.equal(Foo.baz.rlike(1).operator, 'RLIKE');
   assert.equal(Foo.baz.ilike('asdf').operator, 'ILIKE');
   assert.equal(Foo.baz.notIlike('asdf').operator, 'NOT ILIKE');
+  assert.equal(Foo.baz.match('asdf').operator, '@@');
 });

--- a/test/dialects/matches-test.js
+++ b/test/dialects/matches-test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var Harness = require('./support');
+var post = Harness.definePostTable();
+var customerAlias = Harness.defineCustomerAliasTable();
+var sql = require(__dirname + '/../../lib').setDialect('postgres');
+
+//Postgres needs the to_tsquery function to use with @@ operator
+Harness.test({
+  query: post.select(post.star()).where(post.content.match(sql.functions.TO_TSQUERY('hello'))),
+  pg: {
+    text  : 'SELECT "post".* FROM "post" WHERE ("post"."content" @@ TO_TSQUERY($1))',
+    string: 'SELECT "post".* FROM "post" WHERE ("post"."content" @@ TO_TSQUERY(\'hello\'))'
+  },
+  params: ['hello']
+});
+
+
+Harness.test({
+  query: post.select(post.star()).where(post.content.match('hello')),
+  sqlite: {
+    text  : 'SELECT "post".* FROM "post" WHERE ("post"."content" MATCH $1)',
+    string: 'SELECT "post".* FROM "post" WHERE ("post"."content" MATCH \'hello\')'
+  },
+  mysql: {
+    text  : 'SELECT `post`.* FROM `post` WHERE (MATCH `post`.`content` AGAINST ?)',
+    string: 'SELECT `post`.* FROM `post` WHERE (MATCH `post`.`content` AGAINST \'hello\')'
+  },
+  mssql: {
+    text  : 'SELECT [post].* FROM [post] WHERE (CONTAINS ([post].[content], @1))',
+    string: 'SELECT [post].* FROM [post] WHERE (CONTAINS ([post].[content], \'hello\'))'
+  },
+  params: ['hello']
+});
+
+//matches, ordered by best rank first
+Harness.test({
+  query: post.select(post.id, sql.functions.TS_RANK_CD(post.content, sql.functions.TO_TSQUERY('hello')).as('rank')).
+  where(post.content.match(sql.functions.TO_TSQUERY('hello'))).order(sql.functions.TS_RANK_CD(post.content, sql.functions.TO_TSQUERY('hello')).descending()),
+  pg: {
+    text  : 'SELECT "post"."id", TS_RANK_CD("post"."content", TO_TSQUERY($1)) AS "rank" FROM "post" WHERE ("post"."content" @@ TO_TSQUERY($2)) ORDER BY TS_RANK_CD("post"."content", TO_TSQUERY($3)) DESC',
+    string: 'SELECT "post"."id", TS_RANK_CD("post"."content", TO_TSQUERY(\'hello\')) AS "rank" FROM "post" WHERE ("post"."content" @@ TO_TSQUERY(\'hello\')) ORDER BY TS_RANK_CD("post"."content", TO_TSQUERY(\'hello\')) DESC'
+  },
+  params: ['hello','hello','hello']
+});


### PR DESCRIPTION
I need to perform text search queries for my project (using Postgres).  
Here is what i think is needed to perform such queries.  I'm not very familiar yet with your module, please forgive newbie mistakes.

I added the "match" operator (`@@`) to perform text search on a column (`tsvector`).  I also added the standard text search functions to make possible to make a complete query. 

I don't use Mysql, Mssql nor sqlite.  The implementation is based on the documentation I found.
