### PR TITLE
fixes drop index statement for pg

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -877,9 +877,7 @@ Postgres.prototype.visitCreateIndex = function(node) {
 Postgres.prototype.visitDropIndex = function(node) {
   var result = [ 'DROP INDEX' ];
 
-  result.push(this.quote(node.options.indexName));
-  result.push("ON");
-  result.push(this.visit(node.table.toNode()));
+  result.push(this.quote(node.table.getSchema() || "public") + "." + this.quote(node.options.indexName));
 
   return result;
 };

--- a/test/dialects/indexes-tests.js
+++ b/test/dialects/indexes-tests.js
@@ -128,8 +128,8 @@ Harness.test({
     string: 'DROP INDEX "public"."index_name"'
   },
   mysql: {
-    text  : 'DROP INDEX "public"."index_name"',
-    string: 'DROP INDEX "public"."index_name"'
+    text  : 'DROP INDEX `public`.`index_name`',
+    string: 'DROP INDEX `public`.`index_name`'
   },
   sqlite: {
     text  : 'DROP INDEX "public"."index_name"',
@@ -145,8 +145,8 @@ Harness.test({
     string: 'DROP INDEX "public"."post_id_userId"'
   },
   mysql: {
-    text  : 'DROP INDEX "public"."post_id_userId"',
-    string: 'DROP INDEX "public"."post_id_userId"'
+    text  : 'DROP INDEX `public`.`post_id_userId`',
+    string: 'DROP INDEX `public`.`post_id_userId`'
   },
   sqlite: {
     text  : 'DROP INDEX "public"."post_id_userId"',

--- a/test/dialects/indexes-tests.js
+++ b/test/dialects/indexes-tests.js
@@ -124,16 +124,16 @@ Harness.test({
 Harness.test({
   query: post.indexes().drop('index_name'),
   pg: {
-    text  : 'DROP INDEX "index_name" ON "post"',
-    string: 'DROP INDEX "index_name" ON "post"'
+    text  : 'DROP INDEX "public"."index_name"',
+    string: 'DROP INDEX "public"."index_name"'
   },
   mysql: {
-    text  : 'DROP INDEX `index_name` ON `post`',
-    string: 'DROP INDEX `index_name` ON `post`'
+    text  : 'DROP INDEX "public"."index_name"',
+    string: 'DROP INDEX "public"."index_name"'
   },
   sqlite: {
-    text  : 'DROP INDEX "index_name" ON "post"',
-    string: 'DROP INDEX "index_name" ON "post"'
+    text  : 'DROP INDEX "public"."index_name"',
+    string: 'DROP INDEX "public"."index_name"'
   },
   params: []
 });
@@ -141,16 +141,16 @@ Harness.test({
 Harness.test({
   query: post.indexes().drop(post.userId, post.id),
   pg: {
-    text  : 'DROP INDEX "post_id_userId" ON "post"',
-    string: 'DROP INDEX "post_id_userId" ON "post"'
+    text  : 'DROP INDEX "public"."post_id_userId"',
+    string: 'DROP INDEX "public"."post_id_userId"'
   },
   mysql: {
-    text  : 'DROP INDEX `post_id_userId` ON `post`',
-    string: 'DROP INDEX `post_id_userId` ON `post`'
+    text  : 'DROP INDEX "public"."post_id_userId"',
+    string: 'DROP INDEX "public"."post_id_userId"'
   },
   sqlite: {
-    text  : 'DROP INDEX "post_id_userId" ON "post"',
-    string: 'DROP INDEX "post_id_userId" ON "post"'
+    text  : 'DROP INDEX "public"."post_id_userId"',
+    string: 'DROP INDEX "public"."post_id_userId"'
   },
   params: []
 });


### PR DESCRIPTION
there that should be much more readable

since the last pr caused some confusion when i kept the old syntax for mysql and sqlite, i made the change simpler by changing it for all dialects.
