### PR TITLE
Fix composite primary key bug

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -250,13 +250,14 @@ Postgres.prototype.visitCreate = function(create) {
   var result = ['CREATE TABLE'];
   result = result.concat(create.nodes.map(this.visit.bind(this)));
   result.push(this.visit(table.toNode()));
-  this._visitCreateCompoundPrimaryKey = col_nodes.filter(function(n) {
+  var primary_col_nodes = col_nodes.filter(function(n) {
     return n.primaryKey;
-  }).length > 1;
+  });
+  this._visitCreateCompoundPrimaryKey = primary_col_nodes.length > 1;
   var colspec = '(' + col_nodes.map(this.visit.bind(this)).join(', ');
   if (this._visitCreateCompoundPrimaryKey) {
     colspec += ', PRIMARY KEY (';
-    colspec += col_nodes.map(function(node) {
+    colspec += primary_col_nodes.map(function(node) {
       return this.quote(node.name);
     }.bind(this)).join(', ');
     colspec += ')';

--- a/test/dialects/create-table-tests.js
+++ b/test/dialects/create-table-tests.js
@@ -304,18 +304,19 @@ Harness.test({
     columns: {
       group_id: { dataType: 'int', primaryKey: true},
       user_id:  { dataType: 'int', primaryKey: true},
+      desc:  { dataType: 'varchar'}
     }
   }).create(),
   pg: {
-    text  : 'CREATE TABLE "membership" ("group_id" int, "user_id" int, PRIMARY KEY ("group_id", "user_id"))',
-    string: 'CREATE TABLE "membership" ("group_id" int, "user_id" int, PRIMARY KEY ("group_id", "user_id"))',
+    text  : 'CREATE TABLE "membership" ("group_id" int, "user_id" int, "desc" varchar, PRIMARY KEY ("group_id", "user_id"))',
+    string: 'CREATE TABLE "membership" ("group_id" int, "user_id" int, "desc" varchar, PRIMARY KEY ("group_id", "user_id"))',
   },
   sqlite: {
-    text  : 'CREATE TABLE "membership" ("group_id" int, "user_id" int, PRIMARY KEY ("group_id", "user_id"))',
-    string: 'CREATE TABLE "membership" ("group_id" int, "user_id" int, PRIMARY KEY ("group_id", "user_id"))',
+    text  : 'CREATE TABLE "membership" ("group_id" int, "user_id" int, "desc" varchar, PRIMARY KEY ("group_id", "user_id"))',
+    string: 'CREATE TABLE "membership" ("group_id" int, "user_id" int, "desc" varchar, PRIMARY KEY ("group_id", "user_id"))',
   },
   mysql: {
-    text  : 'CREATE TABLE `membership` (`group_id` int, `user_id` int, PRIMARY KEY (`group_id`, `user_id`))',
-    string: 'CREATE TABLE `membership` (`group_id` int, `user_id` int, PRIMARY KEY (`group_id`, `user_id`))',
+    text  : 'CREATE TABLE `membership` (`group_id` int, `user_id` int, `desc` varchar, PRIMARY KEY (`group_id`, `user_id`))',
+    string: 'CREATE TABLE `membership` (`group_id` int, `user_id` int, `desc` varchar, PRIMARY KEY (`group_id`, `user_id`))',
   }
 });

--- a/test/dialects/support.js
+++ b/test/dialects/support.js
@@ -34,7 +34,7 @@ module.exports = {
 
             // test result is correct
             var expectedText = expectedObject.text || expectedObject;
-            assert.equal(compiledQuery.text, expectedText, 'query result');
+            assert.equal(compiledQuery.text, expectedText);
 
             // if params are specified then test these are correct
             var expectedParams = expectedObject.params || expected.params;


### PR DESCRIPTION
Fix a bug that added all columns as composite primary keys (instead of just those with `primaryKey: true`).

Also removed 'query result' from the assert so that more information is given when tests fail (i.e. the expected and retrieved queries).