### PR TITLE
Cross-Platform Testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "lib/",
   "scripts": {
-    "test": "NODE_ENV=test ./node_modules/.bin/mocha"
+    "test": "node ./runtests"
   },
   "engines": {
     "node": "*"

--- a/runtests.js
+++ b/runtests.js
@@ -10,6 +10,7 @@ var options={
 }
 
 var command = path.join(".","node_modules",".bin","mocha")
+
 try {
-childProcess.execSync(command,options)
+  childProcess.execSync(command,options)
 }catch(ex){}

--- a/runtests.js
+++ b/runtests.js
@@ -1,0 +1,15 @@
+var childProcess = require("child_process")
+var path = require("path")
+
+var env = process.env
+env.NODE_ENV = "test"
+
+var options={
+  env:env,
+  stdio:"inherit"
+}
+
+var command = path.join(".","node_modules",".bin","mocha")
+try {
+childProcess.execSync(command,options)
+}catch(ex){}

--- a/runtests.js
+++ b/runtests.js
@@ -4,13 +4,13 @@ var path = require("path")
 var env = process.env
 env.NODE_ENV = "test"
 
-var options={
-  env:env,
-  stdio:"inherit"
+var options = {
+	env:   env,
+	stdio: "inherit",
 }
 
-var command = path.join(".","node_modules",".bin","mocha")
-
+var command = path.join(".", "node_modules", ".bin", "mocha")
+if (process.platform == "win32") command += ".cmd"
 try {
-  childProcess.execSync(command,options)
-}catch(ex){}
+	childProcess.spawn(command, options)
+} catch (ex) {}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
+--reporter dot
 --ui tdd


### PR DESCRIPTION
@lebolo comment on #133 got me thinking about how to make this run cross platform without the user having to do anything special. I first tried changing the test script in the package.json to
```
...
  "scripts": {
    "test": "mocha"
  },
...
``` 
which worked well, except the NODE_ENV was not set to "test". I couldn't figure to any way to get it set in a cross-platform way without writing a NodeJS script. Which is essentially what this pull request contains.

I've tested it on both Windows and OSX and it seems to work. But it would be nice to have someone else check it out.

Also, it requires NodeJS v0.12 since it uses the `childProcess.execSync` function.

This pull request also modifies the mocha.opts file to default the output to "dot" mode. This is the output that I was always seeing since I started working on this project, but something has changed. I'm not sure if the mocha lib was updated or what, but the *default* output is much more verbose now.