### PR TITLE
Minor bug fix to assert existence of references column

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -718,7 +718,7 @@ Postgres.prototype.visitColumn = function(columnNode) {
           columnNode.name +
           ' (REFERENCES statements within CREATE TABLE and ADD COLUMN statements' +
           ' require a table and column)');
-        assert(columnNode.references.table, 'reference.column missing for column ' +
+        assert(columnNode.references.column, 'reference.column missing for column ' +
           columnNode.name +
           ' (REFERENCES statements within CREATE TABLE and ADD COLUMN statements' +
           ' require a table and column)');


### PR DESCRIPTION
Previously duplicated the check for `columnNode.references.table`.