### PR TITLE
Support for temporary tables.

### DIFF
--- a/lib/dialect/mssql.js
+++ b/lib/dialect/mssql.js
@@ -185,7 +185,9 @@ Mssql.prototype.visitColumn = function(columnNode) {
 
 
 Mssql.prototype.visitCreate = function(create) {
-  if (!isCreateIfNotExists(create)) {
+  var isNotExists=isCreateIfNotExists(create)
+  var isTemporary=isCreateTemporary(create)
+  if (!isNotExists && !isTemporary) {
     return Mssql.super_.prototype.visitCreate.call(this, create);
   }
   // Implement our own create if not exists:
@@ -209,6 +211,7 @@ Mssql.prototype.visitCreate = function(create) {
   // if (schema) { whereClause+=' AND TABLE_SCHEMA = schemaResult.join(' ')}
   // Add some tests for this as well
 
+  if (!isNotExists) return createResult
   return ['IF NOT EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES '+whereClause+') BEGIN '+createResult.join(' ')+' END'];
 };
 
@@ -406,6 +409,10 @@ function isCreateIfNotExists(create){
   if (create.nodes.length==0) return false;
   if (create.nodes[0].type!='IF NOT EXISTS') return false;
   return true;
+};
+
+function isCreateTemporary(create){
+  return create.options.isTemporary
 };
 
 function isDropIfExists(drop){

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -247,7 +247,8 @@ Postgres.prototype.visitCreate = function(create) {
   var table = this._queryNode.table;
   var col_nodes = table.columns.map(function(col) { return col.toNode(); });
 
-  var result = ['CREATE TABLE'];
+   var result = ['CREATE TABLE'];
+  if (create.options.isTemporary) result=['CREATE TEMPORARY TABLE']
   result = result.concat(create.nodes.map(this.visit.bind(this)));
   result.push(this.visit(table.toNode()));
   var primary_col_nodes = col_nodes.filter(function(n) {

--- a/lib/node/create.js
+++ b/lib/node/create.js
@@ -3,5 +3,12 @@
 var Node = require(__dirname);
 
 module.exports = Node.define({
-  type: 'CREATE'
+  type: 'CREATE',
+
+  constructor: function(isTemporary) {
+    Node.call(this);
+
+    this.options = { isTemporary: isTemporary};
+  },
+
 });

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -276,7 +276,7 @@ var Query = Node.define({
       this.add(createIndex);
       return createIndex;
     } else {
-      return this.add(new Create());
+      return this.add(new Create(this.table.isTemporary));
     }
   },
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -15,6 +15,7 @@ var Table = function(config) {
   this._name = config.name;
   this._initialConfig = config;
   this.columnWhiteList = !!config.columnWhiteList;
+  this.isTemporary=!!config.isTemporary
   this.snakeToCamel = !!config.snakeToCamel;
   this.columns = [];
   this.table = this;
@@ -130,6 +131,7 @@ Table.prototype.setSchema = function(schema) {
 };
 
 Table.prototype.getName = function() {
+  if (this.sql && this.sql.dialectName=="mssql" && this.isTemporary) return "#"+this._name;
   return this._name;
 };
 

--- a/test/dialects/create-table-tests.js
+++ b/test/dialects/create-table-tests.js
@@ -320,3 +320,64 @@ Harness.test({
     string: 'CREATE TABLE `membership` (`group_id` int, `user_id` int, `desc` varchar, PRIMARY KEY (`group_id`, `user_id`))',
   }
 });
+
+// TEMPORARY TABLE TESTS
+
+// This tests explicitly setting the isTemporary flag to false, as opposed to all the test above here which have it
+// as undefined.
+Harness.test({
+  query: Table.define({
+    name: 'post',
+    columns: [{
+        name: 'id',
+        dataType: 'int'
+      }],
+    isTemporary:false
+  }).create(),
+  pg: {
+    text  : 'CREATE TABLE "post" ("id" int)',
+    string: 'CREATE TABLE "post" ("id" int)'
+  },
+  sqlite: {
+    text  : 'CREATE TABLE "post" ("id" int)',
+    string: 'CREATE TABLE "post" ("id" int)'
+  },
+  mysql: {
+    text  : 'CREATE TABLE `post` (`id` int)',
+    string: 'CREATE TABLE `post` (`id` int)'
+  },
+  mssql: {
+    text  : 'CREATE TABLE [post] ([id] int)',
+    string: 'CREATE TABLE [post] ([id] int)'
+  },
+  params: []
+});
+
+Harness.test({
+  query: Table.define({
+    name: 'post',
+    columns: [{
+        name: 'id',
+        dataType: 'int'
+      }],
+    isTemporary:true
+  }).create(),
+  pg: {
+    text  : 'CREATE TEMPORARY TABLE "post" ("id" int)',
+    string: 'CREATE TEMPORARY TABLE "post" ("id" int)'
+  },
+  sqlite: {
+    text  : 'CREATE TEMPORARY TABLE "post" ("id" int)',
+    string: 'CREATE TEMPORARY TABLE "post" ("id" int)'
+  },
+  mysql: {
+    text  : 'CREATE TEMPORARY TABLE `post` (`id` int)',
+    string: 'CREATE TEMPORARY TABLE `post` (`id` int)'
+  },
+  //mssql: {
+  //  text  : 'CREATE TABLE [#post] ([id] int)',
+  //  string: 'CREATE TABLE [#post] ([id] int)'
+  //},
+  params: []
+});
+


### PR DESCRIPTION
Adding support for temporary tables as requested in issue #188.

Everything works well with the *standard* SQL implementations (PostgreSQL, MySQL, SQLite). This pull request even works for Microsoft SQL Server, except that I can't seem to figure out how to get the tests to run correctly.

In MS SQL temporary tables are defined by placing a "#" before the table name. So in MS SQL
```sql
CREATE TABLE #test
```
is equivalent to PostgreSQL
```sql
CREATE TEMPORARY TABLE test
```

Whenever the temp table is referenced it needs to be preceded by "#".

So what I wanted to do, as you can see in the changes, is modify the Table.getName function to prepend the "#". I tried to do this by looking at the dialectName of the table. This works ok, if you start your app off like:
```javascript
var sql=require("sql")

sql.setDialect("mssql")

var post=sql.define({
  name:"post",
  columns:["id","name"],
  isTemporary:true
})

var query=post.select()
```
But if don't include the initial `sql.setDialect`, the tables get defined with the default dialect, PostgreSQL.

The current way the tests run is that all the tables get defined with the PostgreSQL dialect and the toQuery gets passed the dialect that we're trying to generate.

I'm not sure how to do it, but is seems like the tables should get created with the dialect that is passed to toQuery or something.

As I mentioned above, this code will work in a large number of programs since the dialect is typically known from the start. But it's bad that tests cannot be created.

@brianc if there's something I'm missing, or you can think of a different way to handle this, I would much appreciate the help. 