### PR TITLE
Fixes issue with INSERT statements using a SELECT

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -210,6 +210,8 @@ Postgres.prototype.visitInsert = function(insert) {
     }
   }
 
+  this._visitedInsert = false;
+
   return result;
 };
 
@@ -650,7 +652,7 @@ Postgres.prototype.visitColumn = function(columnNode) {
       txt.push('DISTINCT(');
     }
   }
-  if(!inInsertUpdateClause && !this._visitingCreate && !this._visitingAlter) {
+  if(!inInsertUpdateClause && !this.visitingReturning && !this._visitingCreate && !this._visitingAlter) {
     if(table.alias) {
       txt.push(this.quote(table.alias));
     } else {

--- a/test/column-tests.js
+++ b/test/column-tests.js
@@ -120,7 +120,7 @@ describe('column', function() {
       });
       it('respects AS rename in RETURNING clause', function() {
         assert.equal(table.update({makeMeCamel:0}).returning(table.makeMeCamel.as('rename')).toQuery().text,
-          'UPDATE "sc" SET "make_me_camel" = $1 RETURNING "sc"."make_me_camel" AS "rename"');
+          'UPDATE "sc" SET "make_me_camel" = $1 RETURNING "make_me_camel" AS "rename"');
       });
     });
   });

--- a/test/dialects/ilike-tests.js
+++ b/test/dialects/ilike-tests.js
@@ -18,8 +18,8 @@ Harness.test({
   query: post.insert(post.content, post.userId)
       .select('\'test\'', user.id).from(user).where(user.name.ilike('A%')),
   pg: {
-    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" ILIKE $1)',
-    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" ILIKE \'A%\')'
+    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" ILIKE $1)',
+    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" ILIKE \'A%\')'
   },
   params: ['A%']
 });
@@ -28,8 +28,8 @@ Harness.test({
   query: post.insert([post.content, post.userId])
       .select('\'test\'', user.id).from(user).where(user.name.ilike('A%')),
   pg: {
-    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" ILIKE $1)',
-    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" ILIKE \'A%\')'
+    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" ILIKE $1)',
+    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" ILIKE \'A%\')'
   },
   params: ['A%']
 });
@@ -38,8 +38,8 @@ Harness.test({
   query: post.insert(post.userId)
       .select(user.id).from(user).where(user.name.ilike('A%')),
   pg: {
-    text  : 'INSERT INTO "post" ("userId") SELECT "id" FROM "user" WHERE ("name" ILIKE $1)',
-    string: 'INSERT INTO "post" ("userId") SELECT "id" FROM "user" WHERE ("name" ILIKE \'A%\')'
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" WHERE ("user"."name" ILIKE $1)',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" WHERE ("user"."name" ILIKE \'A%\')'
   },
   params: ['A%']
 });

--- a/test/dialects/insert-tests.js
+++ b/test/dialects/insert-tests.js
@@ -295,16 +295,16 @@ Harness.test({
   query: post.insert(post.content, post.userId)
       .select('\'test\'', user.id).from(user).where(user.name.like('A%')),
   pg: {
-    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" LIKE $1)',
-    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" LIKE \'A%\')'
+    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" LIKE $1)',
+    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" LIKE \'A%\')'
   },
   sqlite: {
-    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" LIKE $1)',
-    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" LIKE \'A%\')'
+    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" LIKE $1)',
+    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" LIKE \'A%\')'
   },
   mysql: {
-    text  : 'INSERT INTO `post` (`content`, `userId`) SELECT \'test\', `id` FROM `user` WHERE (`name` LIKE ?)',
-    string: 'INSERT INTO `post` (`content`, `userId`) SELECT \'test\', `id` FROM `user` WHERE (`name` LIKE \'A%\')'
+    text  : 'INSERT INTO `post` (`content`, `userId`) SELECT \'test\', `user`.`id` FROM `user` WHERE (`user`.`name` LIKE ?)',
+    string: 'INSERT INTO `post` (`content`, `userId`) SELECT \'test\', `user`.`id` FROM `user` WHERE (`user`.`name` LIKE \'A%\')'
   },
   params: ['A%']
 });
@@ -313,16 +313,16 @@ Harness.test({
   query: post.insert([post.content, post.userId])
       .select('\'test\'', user.id).from(user).where(user.name.like('A%')),
   pg: {
-    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" LIKE $1)',
-    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" LIKE \'A%\')'
+    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" LIKE $1)',
+    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" LIKE \'A%\')'
   },
   sqlite: {
-    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" LIKE $1)',
-    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "id" FROM "user" WHERE ("name" LIKE \'A%\')'
+    text  : 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" LIKE $1)',
+    string: 'INSERT INTO "post" ("content", "userId") SELECT \'test\', "user"."id" FROM "user" WHERE ("user"."name" LIKE \'A%\')'
   },
   mysql: {
-    text  : 'INSERT INTO `post` (`content`, `userId`) SELECT \'test\', `id` FROM `user` WHERE (`name` LIKE ?)',
-    string: 'INSERT INTO `post` (`content`, `userId`) SELECT \'test\', `id` FROM `user` WHERE (`name` LIKE \'A%\')'
+    text  : 'INSERT INTO `post` (`content`, `userId`) SELECT \'test\', `user`.`id` FROM `user` WHERE (`user`.`name` LIKE ?)',
+    string: 'INSERT INTO `post` (`content`, `userId`) SELECT \'test\', `user`.`id` FROM `user` WHERE (`user`.`name` LIKE \'A%\')'
   },
   params: ['A%']
 });
@@ -331,16 +331,16 @@ Harness.test({
   query: post.insert(post.userId)
       .select(user.id).from(user).where(user.name.like('A%')),
   pg: {
-    text  : 'INSERT INTO "post" ("userId") SELECT "id" FROM "user" WHERE ("name" LIKE $1)',
-    string: 'INSERT INTO "post" ("userId") SELECT "id" FROM "user" WHERE ("name" LIKE \'A%\')'
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" WHERE ("user"."name" LIKE $1)',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" WHERE ("user"."name" LIKE \'A%\')'
   },
   sqlite: {
-    text  : 'INSERT INTO "post" ("userId") SELECT "id" FROM "user" WHERE ("name" LIKE $1)',
-    string: 'INSERT INTO "post" ("userId") SELECT "id" FROM "user" WHERE ("name" LIKE \'A%\')'
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" WHERE ("user"."name" LIKE $1)',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" WHERE ("user"."name" LIKE \'A%\')'
   },
   mysql: {
-    text  : 'INSERT INTO `post` (`userId`) SELECT `id` FROM `user` WHERE (`name` LIKE ?)',
-    string: 'INSERT INTO `post` (`userId`) SELECT `id` FROM `user` WHERE (`name` LIKE \'A%\')'
+    text  : 'INSERT INTO `post` (`userId`) SELECT `user`.`id` FROM `user` WHERE (`user`.`name` LIKE ?)',
+    string: 'INSERT INTO `post` (`userId`) SELECT `user`.`id` FROM `user` WHERE (`user`.`name` LIKE \'A%\')'
   },
   params: ['A%']
 });

--- a/test/dialects/insert-tests.js
+++ b/test/dialects/insert-tests.js
@@ -345,6 +345,24 @@ Harness.test({
   params: ['A%']
 });
 
+Harness.test({
+  query: post.insert(post.userId)
+      .select(post.userId).from(user.join(post).on(user.id.equals(post.userId))).where(post.tags.like('A%')),
+  pg: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "post"."userId" FROM "user" INNER JOIN "post" ON ("user"."id" = "post"."userId") WHERE ("post"."tags" LIKE $1)',
+    string: 'INSERT INTO "post" ("userId") SELECT "post"."userId" FROM "user" INNER JOIN "post" ON ("user"."id" = "post"."userId") WHERE ("post"."tags" LIKE \'A%\')'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "post"."userId" FROM "user" INNER JOIN "post" ON ("user"."id" = "post"."userId") WHERE ("post"."tags" LIKE $1)',
+    string: 'INSERT INTO "post" ("userId") SELECT "post"."userId" FROM "user" INNER JOIN "post" ON ("user"."id" = "post"."userId") WHERE ("post"."tags" LIKE \'A%\')'
+  },
+  mysql: {
+    text  : 'INSERT INTO `post` (`userId`) SELECT `post`.`userId` FROM `user` INNER JOIN `post` ON (`user`.`id` = `post`.`userId`) WHERE (`post`.`tags` LIKE ?)',
+    string: 'INSERT INTO `post` (`userId`) SELECT `post`.`userId` FROM `user` INNER JOIN `post` ON (`user`.`id` = `post`.`userId`) WHERE (`post`.`tags` LIKE \'A%\')'
+  },
+  params: ['A%']
+});
+
 // Binary inserts
 Harness.test({
   query: post.insert(post.content.value(new Buffer('test')), post.userId.value(2)),


### PR DESCRIPTION
Currently, if you attempt a statement like:
```javascript
var  query=post.insert(post.content,post.userId).select(user.id).from(user).where(user.name.equals("joe")
```
It will generate
```sql
INSERT INTO "post" ("content", "userId") SELECT "id" FROM "user" WHERE ("name" = 'joe')
```
This works fine, until the SELECT statement includes a JOIN at which point the field names need to be qualified. This pull request makes the previous query generate this:
```sql
INSERT INTO "post" ("content", "userId") SELECT "user"."id" FROM "user" WHERE ("user"."name" = 'joe')
```
The only tests inside the insert-tests.js file I changed are ones that deal with SELECT after the insert. So I'm pretty sure I didn't break any other forms of insert.

The other test that I had to change was the "respects AS rename in RETURNING clause" in the column-tests.js. Because of the way the visitColumn was working I think the behavior happened to be right in some cases, when really it wasn't checking the correct flags. Because of the fix I added there, it made this test failed because the returning field is no longer getting qualified with the table. But I don't think it needs to be.

If this request is merged, my other pull request #216 will fail because the MS SQL tests will not be correct. If this can get approved and merged in, I will fix the tests in #216 so everything works correctly.