### PR TITLE
Added support for ON DUPLICATE KEY UPDATE for mysql 

### DIFF
--- a/lib/dialect/mssql.js
+++ b/lib/dialect/mssql.js
@@ -7,8 +7,8 @@ var util = require('util');
 var assert = require('assert');
 
 var Mssql = function() {
-  this.output = [];
-  this.params = [];
+	this.output = [];
+	this.params = [];
 };
 
 var Postgres = require(__dirname + '/postgres');
@@ -22,164 +22,165 @@ Mssql.prototype._quoteCharacter = '[';
 Mssql.prototype._arrayAggFunctionName = '';
 
 Mssql.prototype._getParameterPlaceholder = function(index, value) {
-  return '@' + index;
+	return '@' + index;
 };
 
 Mssql.prototype.visitBinary = function(binary) {
-  if(binary.operator === '@@'){
-    var self = this;
-    var text = '(CONTAINS (' + this.visit(binary.left) + ', ';
-    text += this.visit(binary.right);
-    text += '))';
-    return [text];
-  }
+	if (binary.operator === '@@') {
+		var self = this;
+		var text = '(CONTAINS (' + this.visit(binary.left) + ', ';
+		text += this.visit(binary.right);
+		text += '))';
+		return [text];
+	}
 
-  if (!isRightSideArray(binary)){
-    return Mssql.super_.prototype.visitBinary.call(this, binary);
-  }
-  if (binary.operator=='IN' || binary.operator=='NOT IN'){
-    return Mssql.super_.prototype.visitBinary.call(this, binary);
-  }
-  throw new Error('SQL Sever does not support arrays in this type of expression.');
+	if (!isRightSideArray(binary)) {
+		return Mssql.super_.prototype.visitBinary.call(this, binary);
+	}
+	if (binary.operator == 'IN' || binary.operator == 'NOT IN') {
+		return Mssql.super_.prototype.visitBinary.call(this, binary);
+	}
+	throw new Error('SQL Sever does not support arrays in this type of expression.');
 };
 
 Mssql.prototype.visitAlter = function(alter) {
-  var self=this;
-  var errMsg='ALTER TABLE cannot be used to perform multiple different operations in the same statement.';
+	var self = this;
+	var errMsg = 'ALTER TABLE cannot be used to perform multiple different operations in the same statement.';
 
-  // Implement our own add column:
-  //   PostgreSQL: ALTER TABLE "name" ADD COLUMN "col1", ADD COLUMN "col2"
-  //   Mssql:  ALTER TABLE [name] ADD [col1], [col2]
-  function _addColumn(){
-    self._visitingAlter = true;
-    var table = self._queryNode.table;
-    self._visitingAddColumn = true;
-    var result='ALTER TABLE '+self.visit(table.toNode())+' ADD '+self.visit(alter.nodes[0].nodes[0]);
-    for (var i= 1,len=alter.nodes.length; i<len; i++){
-      var node=alter.nodes[i];
-      assert(node.type=='ADD COLUMN',errMsg);
-      result+=', '+self.visit(node.nodes[0]);
-    }
-    self._visitingAddColumn = false;
-    self._visitingAlter = false;
-    return [result];
-  }
+	// Implement our own add column:
+	//   PostgreSQL: ALTER TABLE "name" ADD COLUMN "col1", ADD COLUMN "col2"
+	//   Mssql:  ALTER TABLE [name] ADD [col1], [col2]
+	function _addColumn() {
+		self._visitingAlter = true;
+		var table = self._queryNode.table;
+		self._visitingAddColumn = true;
+		var result = 'ALTER TABLE ' + self.visit(table.toNode()) + ' ADD ' + self.visit(alter.nodes[0].nodes[0]);
+		for (var i = 1, len = alter.nodes.length; i < len; i++) {
+			var node = alter.nodes[i];
+			assert(node.type == 'ADD COLUMN', errMsg);
+			result += ', ' + self.visit(node.nodes[0]);
+		}
+		self._visitingAddColumn = false;
+		self._visitingAlter = false;
+		return [result];
+	}
 
-  // Implement our own drop column:
-  //   PostgreSQL: ALTER TABLE "name" DROP COLUMN "col1", DROP COLUMN "col2"
-  //   Mssql:  ALTER TABLE [name] DROP COLUMN [col1], [col2]
-  function _dropColumn(){
-    self._visitingAlter = true;
-    var table = self._queryNode.table;
-    var result=[
-      'ALTER TABLE',
-      self.visit(table.toNode())
-    ];
-    var columns='DROP COLUMN '+self.visit(alter.nodes[0].nodes[0]);
-    for (var i= 1,len=alter.nodes.length; i<len; i++){
-      var node=alter.nodes[i];
-      assert(node.type=='DROP COLUMN',errMsg);
-      columns+=', '+self.visit(node.nodes[0]);
-    }
-    result.push(columns);
-    self._visitingAlter = false;
-    return result;
-  }
+	// Implement our own drop column:
+	//   PostgreSQL: ALTER TABLE "name" DROP COLUMN "col1", DROP COLUMN "col2"
+	//   Mssql:  ALTER TABLE [name] DROP COLUMN [col1], [col2]
+	function _dropColumn() {
+		self._visitingAlter = true;
+		var table = self._queryNode.table;
+		var result = [
+			'ALTER TABLE',
+			self.visit(table.toNode())
+		];
+		var columns = 'DROP COLUMN ' + self.visit(alter.nodes[0].nodes[0]);
+		for (var i = 1, len = alter.nodes.length; i < len; i++) {
+			var node = alter.nodes[i];
+			assert(node.type == 'DROP COLUMN', errMsg);
+			columns += ', ' + self.visit(node.nodes[0]);
+		}
+		result.push(columns);
+		self._visitingAlter = false;
+		return result;
+	}
 
-  // Implement our own rename table:
-  //   PostgreSQL: ALTER TABLE "post" RENAME TO "posts"
-  //   Mssql:  EXEC sp_rename [post], [posts]
-  function _rename(){
-    self._visitingAlter = true;
-    var table = self._queryNode.table;
-    var result = ['EXEC sp_rename '+self.visit(table.toNode())+', '+self.visit(alter.nodes[0].nodes[0])];
-    self._visitingAlter = false;
-    return result
-  }
+	// Implement our own rename table:
+	//   PostgreSQL: ALTER TABLE "post" RENAME TO "posts"
+	//   Mssql:  EXEC sp_rename [post], [posts]
+	function _rename() {
+		self._visitingAlter = true;
+		var table = self._queryNode.table;
+		var result = ['EXEC sp_rename ' + self.visit(table.toNode()) + ', ' + self.visit(alter.nodes[0].nodes[0])];
+		self._visitingAlter = false;
+		return result
+	}
 
-  // Implement our own rename column:
-  //   PostgreSQL: ALTER TABLE "group" RENAME COLUMN "userId" TO "newUserId"
-  //   Mssql:  EXEC sp_rename [group], [userId], [newUserId]
-  function _renameColumn(){
-    // TODO: implement this. Need to be able to get the [tableName.Column], which is hard to do with the current way visitXxx works
-    throw new Error('Mssql renaming columns not yet implemented');
-//    self._visitingAlter = true;
-//    var table = self._queryNode.table;
-//    var result = ['EXEC sp_rename '+
-//      self.visit(table.toNode())+'.'+self.visit(alter.nodes[0].nodes[0])+', '+
-//      self.visit(alter.nodes[0].nodes[1])+', '+
-//      "'COLUMN'"
-//      ];
-//    self._visitingAlter = false;
-//    return result
-  }
+	// Implement our own rename column:
+	//   PostgreSQL: ALTER TABLE "group" RENAME COLUMN "userId" TO "newUserId"
+	//   Mssql:  EXEC sp_rename [group], [userId], [newUserId]
+	function _renameColumn() {
+		// TODO: implement this. Need to be able to get the [tableName.Column], which is hard to do with the current way visitXxx works
+		throw new Error('Mssql renaming columns not yet implemented');
+		//    self._visitingAlter = true;
+		//    var table = self._queryNode.table;
+		//    var result = ['EXEC sp_rename '+
+		//      self.visit(table.toNode())+'.'+self.visit(alter.nodes[0].nodes[0])+', '+
+		//      self.visit(alter.nodes[0].nodes[1])+', '+
+		//      "'COLUMN'"
+		//      ];
+		//    self._visitingAlter = false;
+		//    return result
+	}
 
-  if (isAlterAddColumn(alter)) return _addColumn();
-  if (isAlterDropColumn(alter)) return _dropColumn();
-  if (isAlterRename(alter)) return _rename();
-  if (isAlterRenameColumn(alter)) return _renameColumn();
-  return Mssql.super_.prototype.visitAlter.call(this, alter);
+	if (isAlterAddColumn(alter)) return _addColumn();
+	if (isAlterDropColumn(alter)) return _dropColumn();
+	if (isAlterRename(alter)) return _rename();
+	if (isAlterRenameColumn(alter)) return _renameColumn();
+	return Mssql.super_.prototype.visitAlter.call(this, alter);
 };
 
 // Need to implement a special version of CASE since SQL doesn't support
 //   CASE WHEN true THEN xxx END
 //   the "true" has to be a boolean expression like 1=1
 Mssql.prototype.visitCase = function(caseExp) {
-  var _this=this
+	var _this = this
 
-  function _whenValue(node){
-    if (node.type!='PARAMETER') return _this.visit(node);
-    // dealing with a true/false value
-    var val=node.value();
-    if (val==true) return '1=1'; else return '0=1';
-  }
+	function _whenValue(node) {
+		if (node.type != 'PARAMETER') return _this.visit(node);
+		// dealing with a true/false value
+		var val = node.value();
+		if (val == true) return '1=1';
+		else return '0=1';
+	}
 
-  assert(caseExp.whenList.length == caseExp.thenList.length);
+	assert(caseExp.whenList.length == caseExp.thenList.length);
 
-  var self = this;
-  var text = '(CASE';
+	var self = this;
+	var text = '(CASE';
 
-  this.visitingCase = true;
+	this.visitingCase = true;
 
-  for (var i = 0; i < caseExp.whenList.length; i++) {
-    var whenExp = ' WHEN ' + _whenValue(caseExp.whenList[i]);
-    var thenExp = ' THEN ' + this.visit(caseExp.thenList[i]);
-    text += whenExp + thenExp;
-  }
+	for (var i = 0; i < caseExp.whenList.length; i++) {
+		var whenExp = ' WHEN ' + _whenValue(caseExp.whenList[i]);
+		var thenExp = ' THEN ' + this.visit(caseExp.thenList[i]);
+		text += whenExp + thenExp;
+	}
 
-  if (null != caseExp.else && undefined != caseExp.else) {
-    text += ' ELSE ' + this.visit(caseExp.else);
-  }
+	if (null != caseExp.else && undefined != caseExp.else) {
+		text += ' ELSE ' + this.visit(caseExp.else);
+	}
 
-  this.visitingCase = false;
+	this.visitingCase = false;
 
-  text += ' END)';
-  return [text];
+	text += ' END)';
+	return [text];
 }
 
 Mssql.prototype.visitColumn = function(columnNode) {
-  var self=this;
-  var table;
-  var inSelectClause;
+	var self = this;
+	var table;
+	var inSelectClause;
 
-  function _arrayAgg(){
-    throw new Error("SQL Server does not support array_agg.")
-  }
+	function _arrayAgg() {
+		throw new Error("SQL Server does not support array_agg.")
+	}
 
-  function _countStar(){
-    // Implement our own since count(table.*) is invalid in Mssql
-    var result='COUNT(*)'
-    if(inSelectClause && columnNode.alias) {
-      result += ' AS ' + self.quote(columnNode.alias);
-    }
-    return result;
-  }
+	function _countStar() {
+		// Implement our own since count(table.*) is invalid in Mssql
+		var result = 'COUNT(*)'
+		if (inSelectClause && columnNode.alias) {
+			result += ' AS ' + self.quote(columnNode.alias);
+		}
+		return result;
+	}
 
-  table = columnNode.table;
-  inSelectClause = !this._selectOrDeleteEndIndex;
-  if (isCountStarExpression(columnNode)) return _countStar();
-  if (inSelectClause && !table.alias && columnNode.asArray) return _arrayAgg();
-  return Mssql.super_.prototype.visitColumn.call(this, columnNode);
+	table = columnNode.table;
+	inSelectClause = !this._selectOrDeleteEndIndex;
+	if (isCountStarExpression(columnNode)) return _countStar();
+	if (inSelectClause && !table.alias && columnNode.asArray) return _arrayAgg();
+	return Mssql.super_.prototype.visitColumn.call(this, columnNode);
 
 };
 
@@ -216,35 +217,35 @@ Mssql.prototype.visitCreate = function(create) {
 };
 
 Mssql.prototype.visitDrop = function(drop) {
-  if (!isDropIfExists(drop)) {
-    return Mssql.super_.prototype.visitDrop.call(this, drop);
-  }
-  // Implement our own drop if exists:
-  //   PostgreSQL: DROP TABLE IF EXISTS "group"
-  //   Mssql:  IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = [group]) BEGIN ... END
-  var table = this._queryNode.table;
-  var tableResult=this.visit(table.toNode());
+	if (!isDropIfExists(drop)) {
+		return Mssql.super_.prototype.visitDrop.call(this, drop);
+	}
+	// Implement our own drop if exists:
+	//   PostgreSQL: DROP TABLE IF EXISTS "group"
+	//   Mssql:  IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = [group]) BEGIN ... END
+	var table = this._queryNode.table;
+	var tableResult = this.visit(table.toNode());
 
-  var dropResult = ['DROP TABLE'];
-  dropResult.push(tableResult);
+	var dropResult = ['DROP TABLE'];
+	dropResult.push(tableResult);
 
-  var whereClause='WHERE TABLE_NAME = '+tableResult.join(' ');
-  // TODO: need to add schema check, sudo code:
-  // if (schema) { whereClause+=' AND TABLE_SCHEMA = schemaResult.join(' ')}
-  // Add some tests for this as well
+	var whereClause = 'WHERE TABLE_NAME = ' + tableResult.join(' ');
+	// TODO: need to add schema check, sudo code:
+	// if (schema) { whereClause+=' AND TABLE_SCHEMA = schemaResult.join(' ')}
+	// Add some tests for this as well
 
-  return ['IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES '+whereClause+') BEGIN '+dropResult.join(' ')+' END'];
+	return ['IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES ' + whereClause + ') BEGIN ' + dropResult.join(' ') + ' END'];
 };
 
 Mssql.prototype.visitOrderBy = function(orderBy) {
-	var result=Mssql.super_.prototype.visitOrderBy.call(this, orderBy);
-	var offsetNode=orderBy.msSQLOffsetNode;
-	var limitNode=orderBy.msSQLLimitNode;
+	var result = Mssql.super_.prototype.visitOrderBy.call(this, orderBy);
+	var offsetNode = orderBy.msSQLOffsetNode;
+	var limitNode = orderBy.msSQLLimitNode;
 	if (!offsetNode && !limitNode) return result;
-	assert(offsetNode,"Something bad happened, should have had an msSQLOffsetNode here.");
-	result.push("OFFSET "+getModifierValue(this,offsetNode)+" ROWS");
+	assert(offsetNode, "Something bad happened, should have had an msSQLOffsetNode here.");
+	result.push("OFFSET " + getModifierValue(this, offsetNode) + " ROWS");
 	if (!limitNode) return result;
-	result.push("FETCH NEXT "+getModifierValue(this,limitNode)+" ROWS ONLY");
+	result.push("FETCH NEXT " + getModifierValue(this, limitNode) + " ROWS ONLY");
 	return result;
 };
 
@@ -262,7 +263,7 @@ Mssql.prototype.visitOrderBy = function(orderBy) {
  * @param {Node[]} filters
  * @returns {String[]}
  */
-Mssql.prototype.visitQueryHelper=function(actions,targets,filters){
+Mssql.prototype.visitQueryHelper = function(actions, targets, filters) {
 	/**
 	 *
 	 * @param {Node[]} list
@@ -270,23 +271,26 @@ Mssql.prototype.visitQueryHelper=function(actions,targets,filters){
 	 * @returns {Object|undefined} {index:number, node:Node}
 	 * @private
 	 */
-	function _findNode(list,type){
-		for (var i= 0, len=list.length; i<len; i++) {
-			var n=list[i];
-			if (n.type==type) return {index:i,node:n};
+	function _findNode(list, type) {
+		for (var i = 0, len = list.length; i < len; i++) {
+			var n = list[i];
+			if (n.type == type) return {
+				index: i,
+				node: n
+			};
 		}
 		return undefined
 	}
 
-	function _handleLimitAndOffset(){
-		var limitInfo=_findNode(filters,"LIMIT");
-		var offsetInfo=_findNode(filters,"OFFSET");
-		var orderByInfo=_findNode(filters,"ORDER BY");
+	function _handleLimitAndOffset() {
+		var limitInfo = _findNode(filters, "LIMIT");
+		var offsetInfo = _findNode(filters, "OFFSET");
+		var orderByInfo = _findNode(filters, "ORDER BY");
 
 		// no OFFSET or LIMIT then there's nothing special to do
 		if (!offsetInfo && !limitInfo) return;
 		// ORDER BY with OFFSET we have work to do, may consume LIMIT as well
-		if (orderByInfo && offsetInfo) _processOrderByOffsetLimit(orderByInfo,offsetInfo,limitInfo);
+		if (orderByInfo && offsetInfo) _processOrderByOffsetLimit(orderByInfo, offsetInfo, limitInfo);
 		else if (offsetInfo) throw new Error("MS SQL Server does not allow OFFSET without ORDER BY");
 		else if (limitInfo) _processLimit(limitInfo);
 	}
@@ -297,13 +301,13 @@ Mssql.prototype.visitQueryHelper=function(actions,targets,filters){
 	 * @param limitInfo
 	 * @private
 	 */
-	function _processLimit(limitInfo){
-		var selectInfo=_findNode(actions,"SELECT");
-		assert(selectInfo!=undefined,"MS SQL Server requires a SELECT clause when using LIMIT");
+	function _processLimit(limitInfo) {
+		var selectInfo = _findNode(actions, "SELECT");
+		assert(selectInfo != undefined, "MS SQL Server requires a SELECT clause when using LIMIT");
 		// save the LIMIT node with the SELECT node
-		selectInfo.node.msSQLLimitNode=limitInfo.node;
+		selectInfo.node.msSQLLimitNode = limitInfo.node;
 		// remove the LIMIT node from the filters so it doesn't get processed later.
-		filters.splice(limitInfo.index,1);
+		filters.splice(limitInfo.index, 1);
 	}
 
 	/**
@@ -314,13 +318,13 @@ Mssql.prototype.visitQueryHelper=function(actions,targets,filters){
 	 * @param limitInfo
 	 * @private
 	 */
-	function _processOrderByOffsetLimit(orderByInfo,offsetInfo,limitInfo){
+	function _processOrderByOffsetLimit(orderByInfo, offsetInfo, limitInfo) {
 		// save the OFFSET AND LIMIT nodes with the ORDER BY node
-		orderByInfo.node.msSQLOffsetNode=offsetInfo.node;
-		if (limitInfo) orderByInfo.node.msSQLLimitNode=limitInfo.node;
+		orderByInfo.node.msSQLOffsetNode = offsetInfo.node;
+		if (limitInfo) orderByInfo.node.msSQLLimitNode = limitInfo.node;
 		// remove the OFFSET and LIMIT nodes from the filters so they don't get processed later.
-		filters.splice(offsetInfo.index,1);
-		if (limitInfo) filters.splice(limitInfo.index,1);
+		filters.splice(offsetInfo.index, 1);
+		if (limitInfo) filters.splice(limitInfo.index, 1);
 	}
 
 	// MAIN
@@ -329,7 +333,7 @@ Mssql.prototype.visitQueryHelper=function(actions,targets,filters){
 
 	// lazy-man sorting
 	var sortedNodes = actions.concat(targets).concat(filters);
-	for(var i = 0; i < sortedNodes.length; i++) {
+	for (var i = 0; i < sortedNodes.length; i++) {
 		var res = this.visit(sortedNodes[i]);
 		this.output = this.output.concat(res);
 	}
@@ -366,55 +370,59 @@ Mssql.prototype.visitReturning = function() {
 // We deal with SELECT specially so we can add the TOP clause if needed
 Mssql.prototype.visitSelect = function(select) {
 	if (!select.msSQLLimitNode) return Mssql.super_.prototype.visitSelect.call(this, select);
-	var result=[
+	var result = [
 		'SELECT',
-		'TOP('+getModifierValue(this,select.msSQLLimitNode)+')',
+		'TOP(' + getModifierValue(this, select.msSQLLimitNode) + ')',
 		select.nodes.map(this.visit.bind(this)).join(', ')
 	];
 	this._selectOrDeleteEndIndex = this.output.length + result.length;
 	return result;
 };
 
+Mssql.prototype.visitOnDuplicateKeyUpdate = function(update) {
+	throw new Error('Mssql does not allow onDuplicate clause.');
+};
+
 // Node is either an OFFSET or LIMIT node
-function getModifierValue(dialect,node){
+function getModifierValue(dialect, node) {
 	return node.count.type ? dialect.visit(node.count) : node.count
 }
 
-function isAlterAddColumn(alter){
-  if (alter.nodes.length==0) return false;
-  if (alter.nodes[0].type!='ADD COLUMN') return false;
-  return true;
+function isAlterAddColumn(alter) {
+	if (alter.nodes.length == 0) return false;
+	if (alter.nodes[0].type != 'ADD COLUMN') return false;
+	return true;
 };
 
-function isAlterDropColumn(alter){
-  if (alter.nodes.length==0) return false;
-  if (alter.nodes[0].type!='DROP COLUMN') return false;
-  return true;
+function isAlterDropColumn(alter) {
+	if (alter.nodes.length == 0) return false;
+	if (alter.nodes[0].type != 'DROP COLUMN') return false;
+	return true;
 };
 
-function isAlterRename(alter){
-  if (alter.nodes.length==0) return false;
-  if (alter.nodes[0].type!='RENAME') return false;
-  return true;
+function isAlterRename(alter) {
+	if (alter.nodes.length == 0) return false;
+	if (alter.nodes[0].type != 'RENAME') return false;
+	return true;
 };
 
-function isAlterRenameColumn(alter){
-  if (alter.nodes.length==0) return false;
-  if (alter.nodes[0].type!='RENAME COLUMN') return false;
-  return true;
+function isAlterRenameColumn(alter) {
+	if (alter.nodes.length == 0) return false;
+	if (alter.nodes[0].type != 'RENAME COLUMN') return false;
+	return true;
 };
 
-function isCountStarExpression(columnNode){
-  if (!columnNode.aggregator) return false;
-  if (columnNode.aggregator.toLowerCase()!='count') return false;
-  if (!columnNode.star) return false;
-  return true;
+function isCountStarExpression(columnNode) {
+	if (!columnNode.aggregator) return false;
+	if (columnNode.aggregator.toLowerCase() != 'count') return false;
+	if (!columnNode.star) return false;
+	return true;
 };
 
-function isCreateIfNotExists(create){
-  if (create.nodes.length==0) return false;
-  if (create.nodes[0].type!='IF NOT EXISTS') return false;
-  return true;
+function isCreateIfNotExists(create) {
+	if (create.nodes.length == 0) return false;
+	if (create.nodes[0].type != 'IF NOT EXISTS') return false;
+	return true;
 };
 
 function isCreateTemporary(create){
@@ -428,8 +436,8 @@ function isDropIfExists(drop){
 };
 
 // SQL Server does not support array expressions except in the IN clause.
-function isRightSideArray(binary){
-  return Array.isArray(binary.right);
+function isRightSideArray(binary) {
+	return Array.isArray(binary.right);
 };
 
 module.exports = Mssql;

--- a/lib/dialect/mysql.js
+++ b/lib/dialect/mysql.js
@@ -4,8 +4,8 @@ var util = require('util');
 var assert = require('assert');
 
 var Mysql = function() {
-  this.output = [];
-  this.params = [];
+	this.output = [];
+	this.params = [];
 };
 
 var Postgres = require(__dirname + '/postgres');
@@ -19,72 +19,89 @@ Mysql.prototype._quoteCharacter = '`';
 Mysql.prototype._arrayAggFunctionName = 'GROUP_CONCAT';
 
 Mysql.prototype._getParameterPlaceholder = function() {
-  return '?';
+	return '?';
 };
 
 Mysql.prototype._getParameterValue = function(value) {
-  if (Buffer.isBuffer(value)) {
-    value = 'x' + this._getParameterValue(value.toString('hex'));
-  } else {
-    value = Postgres.prototype._getParameterValue.call(this, value);
-  }
-  return value;
+	if (Buffer.isBuffer(value)) {
+		value = 'x' + this._getParameterValue(value.toString('hex'));
+	} else {
+		value = Postgres.prototype._getParameterValue.call(this, value);
+	}
+	return value;
 };
 
 Mysql.prototype.visitReturning = function() {
-  throw new Error('MySQL does not allow returning clause.');
+	throw new Error('MySQL does not allow returning clause.');
 };
 
 Mysql.prototype.visitForShare = function() {
-  throw new Error('MySQL does not allow FOR SHARE clause.');
+	throw new Error('MySQL does not allow FOR SHARE clause.');
 };
 
 Mysql.prototype.visitCreate = function(create) {
-  var result = Mysql.super_.prototype.visitCreate.call(this, create);
-  var engine = this._queryNode.table._initialConfig.engine;
-  var charset = this._queryNode.table._initialConfig.charset;
+	var result = Mysql.super_.prototype.visitCreate.call(this, create);
+	var engine = this._queryNode.table._initialConfig.engine;
+	var charset = this._queryNode.table._initialConfig.charset;
 
-  if ( !! engine) {
-    result.push('ENGINE=' + engine);
-  }
+	if (!!engine) {
+		result.push('ENGINE=' + engine);
+	}
 
-  if ( !! charset) {
-    result.push('DEFAULT CHARSET=' + charset);
-  }
+	if (!!charset) {
+		result.push('DEFAULT CHARSET=' + charset);
+	}
 
-  return result;
+	return result;
 };
 
 Mysql.prototype.visitRenameColumn = function(renameColumn) {
-  var dataType = renameColumn.nodes[1].dataType || renameColumn.nodes[0].dataType;
-  assert(dataType, 'dataType missing for column ' + (renameColumn.nodes[1].name || renameColumn.nodes[0].name || '') +
-    ' (CHANGE COLUMN statements require a dataType)');
-  return ['CHANGE COLUMN ' + this.visit(renameColumn.nodes[0]) + ' ' + this.visit(renameColumn.nodes[1]) + ' ' + dataType];
+	var dataType = renameColumn.nodes[1].dataType || renameColumn.nodes[0].dataType;
+	assert(dataType, 'dataType missing for column ' + (renameColumn.nodes[1].name || renameColumn.nodes[0].name || '') +
+		' (CHANGE COLUMN statements require a dataType)');
+	return ['CHANGE COLUMN ' + this.visit(renameColumn.nodes[0]) + ' ' + this.visit(renameColumn.nodes[1]) + ' ' + dataType];
 };
 
 Mysql.prototype.visitInsert = function(insert) {
-  var result = Postgres.prototype.visitInsert.call(this, insert);
-  if (result[2] === 'DEFAULT VALUES') {
-    result[2] = '() VALUES ()';
-  }
-  return result;
+	var result = Postgres.prototype.visitInsert.call(this, insert);
+	if (result[2] === 'DEFAULT VALUES') {
+		result[2] = '() VALUES ()';
+	}
+	return result;
+};
+
+Mysql.prototype.visitOnDuplicateKeyUpdate = function(update) {
+	// don't auto-generate from clause
+	var params = [];
+	/* jshint boss: true */
+	for (var i = 0, node; node = update.nodes[i]; i++) {
+		this._visitingUpdateTargetColumn = true;
+		var target_col = this.visit(node);
+		this._visitingUpdateTargetColumn = false;
+		params = params.concat(target_col + ' = ' + this.visit(node.value));
+	}
+	var result = [
+		'ON DUPLICATE KEY UPDATE',
+		params.join(', ')
+	];
+	return result;
 };
 
 Mysql.prototype.visitIndexes = function(node) {
-  var tableName = this.visit(this._queryNode.table.toNode())[0];
+	var tableName = this.visit(this._queryNode.table.toNode())[0];
 
-  return "SHOW INDEX FROM " + tableName;
+	return "SHOW INDEX FROM " + tableName;
 };
 
 Mysql.prototype.visitBinary = function(binary) {
-  if (binary.operator === '@@') {
-    var self = this;
-    var text = '(MATCH ' + this.visit(binary.left) + ' AGAINST ';
-    text += this.visit(binary.right);
-    text += ')';
-    return [text];
-  }
-  return Mysql.super_.prototype.visitBinary.call(this, binary);
+	if (binary.operator === '@@') {
+		var self = this;
+		var text = '(MATCH ' + this.visit(binary.left) + ' AGAINST ';
+		text += this.visit(binary.right);
+		text += ')';
+		return [text];
+	}
+	return Mysql.super_.prototype.visitBinary.call(this, binary);
 }
 
 module.exports = Mysql;

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _      = require('lodash');
+var _ = require('lodash');
 var assert = require('assert');
-var From   = require('../node/from');
+var From = require('../node/from');
 var Select = require('../node/select');
-var Table  = require('../table');
+var Table = require('../table');
 
 var Postgres = function() {
-  this.output = [];
-  this.params = [];
+	this.output = [];
+	this.params = [];
 };
 
 Postgres.prototype._myClass = Postgres;
@@ -16,231 +16,287 @@ Postgres.prototype._myClass = Postgres;
 Postgres.prototype._arrayAggFunctionName = 'array_agg';
 
 Postgres.prototype._getParameterText = function(index, value) {
-  if (this._disableParameterPlaceholders) {
-    // do not use placeholder
-    return this._getParameterValue(value);
-  } else {
-    // use placeholder
-    return this._getParameterPlaceholder(index, value);
-  }
+	if (this._disableParameterPlaceholders) {
+		// do not use placeholder
+		return this._getParameterValue(value);
+	} else {
+		// use placeholder
+		return this._getParameterPlaceholder(index, value);
+	}
 };
 
 Postgres.prototype._getParameterValue = function(value) {
-  // handle primitives
-  if (null === value) {
-    value = 'NULL';
-  } else if ('boolean' === typeof value) {
-    value = value ? 'TRUE' : 'FALSE';
-  } else if ('number' === typeof value) {
-    // number is just number
-    value = value;
-  } else if ('string' === typeof value) {
-    // string uses single quote
-    value = this.quote(value, "'");
-  } else if ('object' === typeof value) {
-    if (_.isArray(value)) {
-      // convert each element of the array
-      value = _.map(value, this._getParameterValue, this);
-      value = '(' + value.join(', ') + ')';
-    } else if (_.isFunction(value.toISOString)) {
-      // Date object's default toString format does not get parsed well
-      // Handle date like objects using toISOString
-      value = this._getParameterValue(value.toISOString());
-    } else if (Buffer.isBuffer(value)) {
-      value = this._getParameterValue('\\x' + value.toString('hex'));
-    } else {
-      // rich object represent with string
-      value = this._getParameterValue(value.toString());
-    }
-  } else {
-    throw new Error('Unable to use ' + value + ' in query');
-  }
+	// handle primitives
+	if (null === value) {
+		value = 'NULL';
+	} else if ('boolean' === typeof value) {
+		value = value ? 'TRUE' : 'FALSE';
+	} else if ('number' === typeof value) {
+		// number is just number
+		value = value;
+	} else if ('string' === typeof value) {
+		// string uses single quote
+		value = this.quote(value, "'");
+	} else if ('object' === typeof value) {
+		if (_.isArray(value)) {
+			// convert each element of the array
+			value = _.map(value, this._getParameterValue, this);
+			value = '(' + value.join(', ') + ')';
+		} else if (_.isFunction(value.toISOString)) {
+			// Date object's default toString format does not get parsed well
+			// Handle date like objects using toISOString
+			value = this._getParameterValue(value.toISOString());
+		} else if (Buffer.isBuffer(value)) {
+			value = this._getParameterValue('\\x' + value.toString('hex'));
+		} else {
+			// rich object represent with string
+			value = this._getParameterValue(value.toString());
+		}
+	} else {
+		throw new Error('Unable to use ' + value + ' in query');
+	}
 
-  // value has been converted at this point
-  return value;
+	// value has been converted at this point
+	return value;
 };
 
 Postgres.prototype._getParameterPlaceholder = function(index, value) {
-  /* jshint unused: false */
-  return '$' + index;
+	/* jshint unused: false */
+	return '$' + index;
 };
 
 Postgres.prototype.getQuery = function(queryNode) {
-  // passed in a table, not a query
-  if (queryNode instanceof Table) {
-    queryNode = queryNode.select(queryNode.star());
-  }
-  this.output = this.visit(queryNode);
+	// passed in a table, not a query
+	if (queryNode instanceof Table) {
+		queryNode = queryNode.select(queryNode.star());
+	}
+	this.output = this.visit(queryNode);
 
-  // create the query object
-  var query = { text: this.output.join(' '), values: this.params };
+	// create the query object
+	var query = {
+		text: this.output.join(' '),
+		values: this.params
+	};
 
-  // reset the internal state of this builder
-  this.output = [];
-  this.params = [];
+	// reset the internal state of this builder
+	this.output = [];
+	this.params = [];
 
-  return query;
+	return query;
 };
 
 Postgres.prototype.getString = function(queryNode) {
-  // switch off parameter placeholders
-  var previousFlagStatus = this._disableParameterPlaceholders;
-  this._disableParameterPlaceholders = true;
-  var query;
-  try {
-    // use the same code path for query building
-    query = this.getQuery(queryNode);
-  } finally {
-    // always restore the flag afterwards
-    this._disableParameterPlaceholders = previousFlagStatus;
-  }
-  return query.text;
+	// switch off parameter placeholders
+	var previousFlagStatus = this._disableParameterPlaceholders;
+	this._disableParameterPlaceholders = true;
+	var query;
+	try {
+		// use the same code path for query building
+		query = this.getQuery(queryNode);
+	} finally {
+		// always restore the flag afterwards
+		this._disableParameterPlaceholders = previousFlagStatus;
+	}
+	return query.text;
 };
 
 Postgres.prototype.visit = function(node) {
-  switch(node.type) {
-    case 'QUERY'           : return this.visitQuery(node);
-    case 'SUBQUERY'        : return this.visitSubquery(node);
-    case 'SELECT'          : return this.visitSelect(node);
-    case 'INSERT'          : return this.visitInsert(node);
-    case 'UPDATE'          : return this.visitUpdate(node);
-    case 'DELETE'          : return this.visitDelete(node);
-    case 'CREATE'          : return this.visitCreate(node);
-    case 'DROP'            : return this.visitDrop(node);
-    case 'ALIAS'           : return this.visitAlias(node);
-    case 'ALTER'           : return this.visitAlter(node);
-    case 'CAST'            : return this.visitCast(node);
-    case 'FROM'            : return this.visitFrom(node);
-    case 'WHERE'           : return this.visitWhere(node);
-    case 'ORDER BY'        : return this.visitOrderBy(node);
-    case 'ORDER BY VALUE'  : return this.visitOrderByValue(node);
-    case 'GROUP BY'        : return this.visitGroupBy(node);
-    case 'HAVING'          : return this.visitHaving(node);
-    case 'RETURNING'       : return this.visitReturning(node);
-    case 'FOR UPDATE'      : return this.visitForUpdate();
-    case 'FOR SHARE'       : return this.visitForShare();
-    case 'TABLE'           : return this.visitTable(node);
-    case 'COLUMN'          : return this.visitColumn(node);
-    case 'JOIN'            : return this.visitJoin(node);
-    case 'LITERAL'         : return this.visitLiteral(node);
-    case 'TEXT'            : return node.text;
-    case 'PARAMETER'       : return this.visitParameter(node);
-    case 'DEFAULT'         : return this.visitDefault(node);
-    case 'IF EXISTS'       : return this.visitIfExists();
-    case 'IF NOT EXISTS'   : return this.visitIfNotExists();
-    case 'CASCADE'         : return this.visitCascade();
-    case 'RESTRICT'        : return this.visitRestrict();
-    case 'RENAME'          : return this.visitRename(node);
-    case 'ADD COLUMN'      : return this.visitAddColumn(node);
-    case 'DROP COLUMN'     : return this.visitDropColumn(node);
-    case 'RENAME COLUMN'   : return this.visitRenameColumn(node);
-    case 'INDEXES'         : return this.visitIndexes(node);
-    case 'CREATE INDEX'    : return this.visitCreateIndex(node);
-    case 'DROP INDEX'      : return this.visitDropIndex(node);
-    case 'FUNCTION CALL'   : return this.visitFunctionCall(node);
-    case 'ARRAY CALL'      : return this.visitArrayCall(node);
+	switch (node.type) {
+		case 'QUERY':
+			return this.visitQuery(node);
+		case 'SUBQUERY':
+			return this.visitSubquery(node);
+		case 'SELECT':
+			return this.visitSelect(node);
+		case 'INSERT':
+			return this.visitInsert(node);
+		case 'UPDATE':
+			return this.visitUpdate(node);
+		case 'ON DUPLICATE KEY UPDATE':
+			return this.visitOnDuplicateKeyUpdate(node);
+		case 'DELETE':
+			return this.visitDelete(node);
+		case 'CREATE':
+			return this.visitCreate(node);
+		case 'DROP':
+			return this.visitDrop(node);
+		case 'ALIAS':
+			return this.visitAlias(node);
+		case 'ALTER':
+			return this.visitAlter(node);
+		case 'CAST':
+			return this.visitCast(node);
+		case 'FROM':
+			return this.visitFrom(node);
+		case 'WHERE':
+			return this.visitWhere(node);
+		case 'ORDER BY':
+			return this.visitOrderBy(node);
+		case 'ORDER BY VALUE':
+			return this.visitOrderByValue(node);
+		case 'GROUP BY':
+			return this.visitGroupBy(node);
+		case 'HAVING':
+			return this.visitHaving(node);
+		case 'RETURNING':
+			return this.visitReturning(node);
+		case 'FOR UPDATE':
+			return this.visitForUpdate();
+		case 'FOR SHARE':
+			return this.visitForShare();
+		case 'TABLE':
+			return this.visitTable(node);
+		case 'COLUMN':
+			return this.visitColumn(node);
+		case 'JOIN':
+			return this.visitJoin(node);
+		case 'LITERAL':
+			return this.visitLiteral(node);
+		case 'TEXT':
+			return node.text;
+		case 'PARAMETER':
+			return this.visitParameter(node);
+		case 'DEFAULT':
+			return this.visitDefault(node);
+		case 'IF EXISTS':
+			return this.visitIfExists();
+		case 'IF NOT EXISTS':
+			return this.visitIfNotExists();
+		case 'CASCADE':
+			return this.visitCascade();
+		case 'RESTRICT':
+			return this.visitRestrict();
+		case 'RENAME':
+			return this.visitRename(node);
+		case 'ADD COLUMN':
+			return this.visitAddColumn(node);
+		case 'DROP COLUMN':
+			return this.visitDropColumn(node);
+		case 'RENAME COLUMN':
+			return this.visitRenameColumn(node);
+		case 'INDEXES':
+			return this.visitIndexes(node);
+		case 'CREATE INDEX':
+			return this.visitCreateIndex(node);
+		case 'DROP INDEX':
+			return this.visitDropIndex(node);
+		case 'FUNCTION CALL':
+			return this.visitFunctionCall(node);
+		case 'ARRAY CALL':
+			return this.visitArrayCall(node);
 
-    case 'POSTFIX UNARY' : return this.visitPostfixUnary(node);
-    case 'PREFIX UNARY'  : return this.visitPrefixUnary(node);
-    case 'BINARY'        : return this.visitBinary(node);
-    case 'TERNARY'       : return this.visitTernary(node);
-    case 'IN'            : return this.visitIn(node);
-    case 'NOT IN'        : return this.visitNotIn(node);
-    case 'CASE'          : return this.visitCase(node);
-    case 'AT'            : return this.visitAt(node);
-    case 'SLICE'         : return this.visitSlice(node);
+		case 'POSTFIX UNARY':
+			return this.visitPostfixUnary(node);
+		case 'PREFIX UNARY':
+			return this.visitPrefixUnary(node);
+		case 'BINARY':
+			return this.visitBinary(node);
+		case 'TERNARY':
+			return this.visitTernary(node);
+		case 'IN':
+			return this.visitIn(node);
+		case 'NOT IN':
+			return this.visitNotIn(node);
+		case 'CASE':
+			return this.visitCase(node);
+		case 'AT':
+			return this.visitAt(node);
+		case 'SLICE':
+			return this.visitSlice(node);
 
-    case 'LIMIT' :
-    case 'OFFSET':
-      return this.visitModifier(node);
-    default:
-      throw new Error("Unrecognized node type " + node.type);
-  }
+		case 'LIMIT':
+		case 'OFFSET':
+			return this.visitModifier(node);
+		default:
+			throw new Error("Unrecognized node type " + node.type);
+	}
 };
 
 Postgres.prototype._quoteCharacter = '"';
 Postgres.prototype.quote = function(word, quoteCharacter) {
-  var q;
-  if (quoteCharacter) {
-    // use the specified quote character if given
-    q = quoteCharacter;
-  } else {
-    q = this._quoteCharacter;
-  }
-  // handle square brackets specially
-  if (q=='['){
-    return '['+word+']'
-  } else {
-    return q + word.replace(new RegExp(q,'g'),q+q) + q;
-  }
+	var q;
+	if (quoteCharacter) {
+		// use the specified quote character if given
+		q = quoteCharacter;
+	} else {
+		q = this._quoteCharacter;
+	}
+	// handle square brackets specially
+	if (q == '[') {
+		return '[' + word + ']'
+	} else {
+		return q + word.replace(new RegExp(q, 'g'), q + q) + q;
+	}
 };
 
 Postgres.prototype.visitSelect = function(select) {
-  var result = ['SELECT', select.nodes.map(this.visit.bind(this)).join(', ')];
-  this._selectOrDeleteEndIndex = this.output.length + result.length;
-  return result;
+	var result = ['SELECT', select.nodes.map(this.visit.bind(this)).join(', ')];
+	this._selectOrDeleteEndIndex = this.output.length + result.length;
+	return result;
 };
 
 Postgres.prototype.visitInsert = function(insert) {
-  var self = this;
-  // don't use table.column for inserts
-  this._visitedInsert = true;
+	var self = this;
+	// don't use table.column for inserts
+	this._visitedInsert = true;
 
-  var result = [
-    'INSERT INTO',
-    this.visit(this._queryNode.table.toNode()),
-    '(' + insert.columns.map(this.visit.bind(this)).join(', ') + ')'
-  ];
+	var result = [
+		'INSERT INTO',
+		this.visit(this._queryNode.table.toNode()),
+		'(' + insert.columns.map(this.visit.bind(this)).join(', ') + ')'
+	];
 
-  var paramNodes = insert.getParameters();
+	var paramNodes = insert.getParameters();
 
-  if (paramNodes.length > 0) {
-    var paramText = paramNodes.map(function (paramSet) {
-        return paramSet.map(function (param) {
-          return self.visit(param);
-        }).join(', ');
-      }).map(function (param) {
-        return '('+param+')';
-      }).join(', ');
+	if (paramNodes.length > 0) {
+		var paramText = paramNodes.map(function(paramSet) {
+			return paramSet.map(function(param) {
+				return self.visit(param);
+			}).join(', ');
+		}).map(function(param) {
+			return '(' + param + ')';
+		}).join(', ');
 
-    result.push('VALUES', paramText);
+		result.push('VALUES', paramText);
 
-    if (result.slice(2, 5).join(' ') === '() VALUES ()') {
-      result.splice(2, 3, 'DEFAULT VALUES');
-    }
-  }
+		if (result.slice(2, 5).join(' ') === '() VALUES ()') {
+			result.splice(2, 3, 'DEFAULT VALUES');
+		}
+	}
 
-  this._visitedInsert = false;
-
-  return result;
+	return result;
 };
 
 Postgres.prototype.visitUpdate = function(update) {
-  // don't auto-generate from clause
-  var params = [];
-  /* jshint boss: true */
-  for(var i = 0, node; node = update.nodes[i]; i++) {
-    this._visitingUpdateTargetColumn = true;
-    var target_col = this.visit(node);
-    this._visitingUpdateTargetColumn = false;
-    params = params.concat(target_col + ' = ' + this.visit(node.value));
-  }
-  var result = [
-    'UPDATE',
-    this.visit(this._queryNode.table.toNode()),
-    'SET',
-    params.join(', ')
-  ];
-  return result;
+	// don't auto-generate from clause
+	var params = [];
+	/* jshint boss: true */
+	for (var i = 0, node; node = update.nodes[i]; i++) {
+		this._visitingUpdateTargetColumn = true;
+		var target_col = this.visit(node);
+		this._visitingUpdateTargetColumn = false;
+		params = params.concat(target_col + ' = ' + this.visit(node.value));
+	}
+	var result = [
+		'UPDATE',
+		this.visit(this._queryNode.table.toNode()),
+		'SET',
+		params.join(', ')
+	];
+	return result;
 };
 
-Postgres.prototype.visitDelete = function (del) {
-  var result = ['DELETE'];
-  if (del.nodes.length) {
-    result.push(del.nodes.map(this.visit.bind(this)).join(', '));
-  }
-  this._selectOrDeleteEndIndex = result.length;
-  return result;
+Postgres.prototype.visitOnDuplicateKeyUpdate = function(update) {
+	throw new Error('PostgreSQL does not allow onDuplicate clause.');
+};
+
+Postgres.prototype.visitDelete = function(del) {
+	var result = ['DELETE'];
+	if (del.nodes.length) {
+		result.push(del.nodes.map(this.visit.bind(this)).join(', '));
+	}
+	this._selectOrDeleteEndIndex = result.length;
+	return result;
 };
 
 Postgres.prototype.visitCreate = function(create) {
@@ -273,300 +329,298 @@ Postgres.prototype.visitCreate = function(create) {
 };
 
 Postgres.prototype.visitDrop = function(drop) {
-  // don't auto-generate from clause
-  var result = ['DROP TABLE'];
-  result = result.concat(drop.nodes.map(this.visit.bind(this)));
-  return result;
+	// don't auto-generate from clause
+	var result = ['DROP TABLE'];
+	result = result.concat(drop.nodes.map(this.visit.bind(this)));
+	return result;
 };
 
 Postgres.prototype.visitAlias = function(alias) {
-  var result = [this.visit(alias.value) + ' AS ' + this.quote(alias.alias)];
-  return result;
+	var result = [this.visit(alias.value) + ' AS ' + this.quote(alias.alias)];
+	return result;
 };
 
 Postgres.prototype.visitAlter = function(alter) {
-  this._visitingAlter = true;
-  // don't auto-generate from clause
-  var table = this._queryNode.table;
-  var result = [
-    'ALTER TABLE',
-    this.visit(table.toNode()),
-    alter.nodes.map(this.visit.bind(this)).join(', ')
-  ];
-  this._visitingAlter = false;
-  return result;
+	this._visitingAlter = true;
+	// don't auto-generate from clause
+	var table = this._queryNode.table;
+	var result = [
+		'ALTER TABLE',
+		this.visit(table.toNode()),
+		alter.nodes.map(this.visit.bind(this)).join(', ')
+	];
+	this._visitingAlter = false;
+	return result;
 };
 
 Postgres.prototype.visitCast = function(cast) {
-  var result = ['CAST(' + this.visit(cast.value) + ' AS ' + cast.dataType + ')'];
-  return result;
+	var result = ['CAST(' + this.visit(cast.value) + ' AS ' + cast.dataType + ')'];
+	return result;
 };
 
 Postgres.prototype.visitFrom = function(from) {
-  var result = [];
-  if (from.skipFromStatement) {
-    result.push(',');
-  } else {
-    result.push('FROM');
-  }
-  for(var i = 0; i < from.nodes.length; i++) {
-    result = result.concat(this.visit(from.nodes[i]));
-  }
-  return result;
+	var result = [];
+	if (from.skipFromStatement) {
+		result.push(',');
+	} else {
+		result.push('FROM');
+	}
+	for (var i = 0; i < from.nodes.length; i++) {
+		result = result.concat(this.visit(from.nodes[i]));
+	}
+	return result;
 };
 
 Postgres.prototype.visitWhere = function(where) {
-  this._visitingWhere = true;
-  var result = ['WHERE', where.nodes.map(this.visit.bind(this)).join(', ')];
-  this._visitingWhere = false;
-  return result;
+	this._visitingWhere = true;
+	var result = ['WHERE', where.nodes.map(this.visit.bind(this)).join(', ')];
+	this._visitingWhere = false;
+	return result;
 };
 
 Postgres.prototype.visitOrderBy = function(orderBy) {
-  var result = ['ORDER BY', orderBy.nodes.map(this.visit.bind(this)).join(', ')];
-  return result;
+	var result = ['ORDER BY', orderBy.nodes.map(this.visit.bind(this)).join(', ')];
+	return result;
 };
 
 Postgres.prototype.visitOrderByValue = function(orderByValue) {
-  var text = this.visit(orderByValue.value);
-  if (orderByValue.direction) {
-    text += ' ' + this.visit(orderByValue.direction);
-  }
-  return [text];
+	var text = this.visit(orderByValue.value);
+	if (orderByValue.direction) {
+		text += ' ' + this.visit(orderByValue.direction);
+	}
+	return [text];
 };
 
 Postgres.prototype.visitGroupBy = function(groupBy) {
-  var result = ['GROUP BY', groupBy.nodes.map(this.visit.bind(this)).join(', ')];
-  return result;
+	var result = ['GROUP BY', groupBy.nodes.map(this.visit.bind(this)).join(', ')];
+	return result;
 };
 
 Postgres.prototype.visitHaving = function(having) {
-  var result = ['HAVING', having.nodes.map(this.visit.bind(this)).join(' AND ')];
-  return result;
+	var result = ['HAVING', having.nodes.map(this.visit.bind(this)).join(' AND ')];
+	return result;
 };
 
 Postgres.prototype.visitPrefixUnary = function(unary) {
-  var text = '(' + unary.operator + ' ' + this.visit(unary.left) + ')';
-  return [text];
+	var text = '(' + unary.operator + ' ' + this.visit(unary.left) + ')';
+	return [text];
 };
 
 Postgres.prototype.visitPostfixUnary = function(unary) {
-  var text = '(' + this.visit(unary.left) + ' ' + unary.operator + ')';
-  return [text];
+	var text = '(' + this.visit(unary.left) + ' ' + unary.operator + ')';
+	return [text];
 };
 
 Postgres.prototype.visitBinary = function(binary) {
-  var self = this;
-  var text = '(' + this.visit(binary.left) + ' ' + binary.operator + ' ';
-  if (Array.isArray(binary.right)) {
-    text += '(' + binary.right.map(function (node) {
-      return self.visit(node);
-    }).join(', ') + ')';
-  }
-  else {
-    text += this.visit(binary.right);
-  }
-  text += ')';
-  return [text];
+	var self = this;
+	var text = '(' + this.visit(binary.left) + ' ' + binary.operator + ' ';
+	if (Array.isArray(binary.right)) {
+		text += '(' + binary.right.map(function(node) {
+			return self.visit(node);
+		}).join(', ') + ')';
+	} else {
+		text += this.visit(binary.right);
+	}
+	text += ')';
+	return [text];
 };
 
 Postgres.prototype.visitTernary = function(ternary) {
-  var self = this;
-  var text = '(' + this.visit(ternary.left) + ' ' + ternary.operator + ' ';
+	var self = this;
+	var text = '(' + this.visit(ternary.left) + ' ' + ternary.operator + ' ';
 
-  var visitPart = function(value) {
-    var text = '';
-    if (Array.isArray(value)) {
-      text += '(' + value.map(function (node) {
-        return self.visit(node);
-      }).join(', ') + ')';
-    }
-    else {
-      text += self.visit(value);
-    }
-    return text;
-  };
+	var visitPart = function(value) {
+		var text = '';
+		if (Array.isArray(value)) {
+			text += '(' + value.map(function(node) {
+				return self.visit(node);
+			}).join(', ') + ')';
+		} else {
+			text += self.visit(value);
+		}
+		return text;
+	};
 
-  text += visitPart(ternary.middle);
-  text += ' ' + ternary.separator + ' ';
-  text += visitPart(ternary.right);
+	text += visitPart(ternary.middle);
+	text += ' ' + ternary.separator + ' ';
+	text += visitPart(ternary.right);
 
-  text += ')';
-  return [text];
+	text += ')';
+	return [text];
 };
 
 Postgres.prototype.visitIn = function(binary) {
-  var self = this;
-  var text = '(';
+	var self = this;
+	var text = '(';
 
-  if (Array.isArray(binary.right)) {
-    if (binary.right.length) {
-      var params  = [];
-      var hasNull = false;
+	if (Array.isArray(binary.right)) {
+		if (binary.right.length) {
+			var params = [];
+			var hasNull = false;
 
-      binary.right.forEach(function(node) {
-        if (node.type === 'PARAMETER' && node._val === null) {
-          hasNull = true;
-        } else {
-          params.push(self.visit(node));
-        }
-      });
+			binary.right.forEach(function(node) {
+				if (node.type === 'PARAMETER' && node._val === null) {
+					hasNull = true;
+				} else {
+					params.push(self.visit(node));
+				}
+			});
 
-      if (params.length) {
-        text += this.visit(binary.left) + ' IN (' + params.join(', ') + ')';
+			if (params.length) {
+				text += this.visit(binary.left) + ' IN (' + params.join(', ') + ')';
 
-        if (hasNull) {
-          text += ' OR ' + this.visit(binary.left) + ' IS NULL';
-        }
-      } else { // implicitely has null
-        text += this.visit(binary.left) + ' IS NULL';
-      }
-    } else {
-      text += '1=0';
-    }
-  } else {
-    text += this.visit(binary.left) + ' IN ' + this.visit(binary.right);
-  }
+				if (hasNull) {
+					text += ' OR ' + this.visit(binary.left) + ' IS NULL';
+				}
+			} else { // implicitely has null
+				text += this.visit(binary.left) + ' IS NULL';
+			}
+		} else {
+			text += '1=0';
+		}
+	} else {
+		text += this.visit(binary.left) + ' IN ' + this.visit(binary.right);
+	}
 
-  text += ')';
-  return [text];
+	text += ')';
+	return [text];
 };
 
 Postgres.prototype.visitNotIn = function(binary) {
-  var self = this;
-  var text = '(';
+	var self = this;
+	var text = '(';
 
-  if (Array.isArray(binary.right)) {
-    if (binary.right.length) {
-      var params  = [];
-      var hasNull = false;
+	if (Array.isArray(binary.right)) {
+		if (binary.right.length) {
+			var params = [];
+			var hasNull = false;
 
-      binary.right.forEach(function(node) {
-        if (node.type === 'PARAMETER' && node._val === null) {
-          hasNull = true;
-        } else {
-          params.push(self.visit(node));
-        }
-      });
+			binary.right.forEach(function(node) {
+				if (node.type === 'PARAMETER' && node._val === null) {
+					hasNull = true;
+				} else {
+					params.push(self.visit(node));
+				}
+			});
 
-      if (params.length && hasNull) {
-        text += 'NOT (';
-        text += this.visit(binary.left) + ' IN (' + params.join(', ') + ')';
-        text += ' OR ' + this.visit(binary.left) + ' IS NULL';
-        text += ')';
-      } else if (params.length) {
-        text += this.visit(binary.left) + ' NOT IN (' + params.join(', ') + ')';
-      } else { // implicitely has null
-        text += this.visit(binary.left) + ' IS NOT NULL';
-      }
-    } else {
-      text += '1=1';
-    }
-  } else {
-    text += this.visit(binary.left) + ' NOT IN ' + this.visit(binary.right);
-  }
+			if (params.length && hasNull) {
+				text += 'NOT (';
+				text += this.visit(binary.left) + ' IN (' + params.join(', ') + ')';
+				text += ' OR ' + this.visit(binary.left) + ' IS NULL';
+				text += ')';
+			} else if (params.length) {
+				text += this.visit(binary.left) + ' NOT IN (' + params.join(', ') + ')';
+			} else { // implicitely has null
+				text += this.visit(binary.left) + ' IS NOT NULL';
+			}
+		} else {
+			text += '1=1';
+		}
+	} else {
+		text += this.visit(binary.left) + ' NOT IN ' + this.visit(binary.right);
+	}
 
-  text += ')';
-  return [text];
+	text += ')';
+	return [text];
 };
 
 Postgres.prototype.visitCase = function(caseExp) {
-  assert(caseExp.whenList.length == caseExp.thenList.length);
+	assert(caseExp.whenList.length == caseExp.thenList.length);
 
-  var self = this;
-  var text = '(CASE';
+	var self = this;
+	var text = '(CASE';
 
-  this.visitingCase = true;
+	this.visitingCase = true;
 
-  for (var i = 0; i < caseExp.whenList.length; i++) {
-    var whenExp = ' WHEN ' + this.visit(caseExp.whenList[i]);
-    var thenExp = ' THEN ' + this.visit(caseExp.thenList[i]);
-    text += whenExp + thenExp;
-  }
+	for (var i = 0; i < caseExp.whenList.length; i++) {
+		var whenExp = ' WHEN ' + this.visit(caseExp.whenList[i]);
+		var thenExp = ' THEN ' + this.visit(caseExp.thenList[i]);
+		text += whenExp + thenExp;
+	}
 
-  if (null != caseExp.else && undefined != caseExp.else) {
-    text += ' ELSE ' + this.visit(caseExp.else);
-  }
+	if (null != caseExp.else && undefined != caseExp.else) {
+		text += ' ELSE ' + this.visit(caseExp.else);
+	}
 
-  this.visitingCase = false;
+	this.visitingCase = false;
 
-  text += ' END)';
-  return [text];
+	text += ' END)';
+	return [text];
 }
 
 Postgres.prototype.visitAt = function(at) {
-  var text = '(' + this.visit(at.value) + ')[' + this.visit(at.index) + ']';
-  return [text];
+	var text = '(' + this.visit(at.value) + ')[' + this.visit(at.index) + ']';
+	return [text];
 };
 
 Postgres.prototype.visitSlice = function(slice) {
-  var text = '(' + this.visit(slice.value) + ')';
-  text += '[' + this.visit(slice.start) + ':' + this.visit(slice.end) + ']';
-  return [text];
+	var text = '(' + this.visit(slice.value) + ')';
+	text += '[' + this.visit(slice.start) + ':' + this.visit(slice.end) + ']';
+	return [text];
 };
 
 Postgres.prototype.visitContains = function(contains) {
-  var text = this.visit(contains.value);
-  text += ' @> ' + this.visit(contains.set);
-  return [text];
+	var text = this.visit(contains.value);
+	text += ' @> ' + this.visit(contains.set);
+	return [text];
 };
 
 Postgres.prototype.visitContainedBy = function(containedBy) {
-  var text = this.visit(containedBy.value);
-  text += ' <@ ' + this.visit(containedBy.set);
-  return [text];
+	var text = this.visit(containedBy.value);
+	text += ' <@ ' + this.visit(containedBy.set);
+	return [text];
 };
 
 Postgres.prototype.visitOverlap = function(overlap) {
-  var text = this.visit(overlap.value);
-  text += ' && ' + this.visit(overlap.set);
-  return [text];
+	var text = this.visit(overlap.value);
+	text += ' && ' + this.visit(overlap.set);
+	return [text];
 };
 
 Postgres.prototype.visitQuery = function(queryNode) {
-  this._queryNode = queryNode;
-  // need to sort the top level query nodes on visitation priority
-  // so select/insert/update/delete comes before from comes before where
-  var missingFrom = true;
-  var hasFrom     = false;
-  var actions = [];
-  var targets = [];
-  var filters = [];
-  for(var i = 0; i < queryNode.nodes.length; i++) {
-    var node = queryNode.nodes[i];
-    switch(node.type) {
-      case "SELECT":
-      case "DELETE":
-        actions.push(node);
-        break;
-      case "INDEXES":
-      case "INSERT":
-      case "UPDATE":
-      case "CREATE":
-      case "DROP":
-      case "ALTER":
-        actions.push(node);
-        missingFrom = false;
-        break;
-      case "FROM":
-        node.skipFromStatement = hasFrom;
-        hasFrom = true;
-        missingFrom = false;
-        targets.push(node);
-        break;
-      default:
-        filters.push(node);
-        break;
-    }
-  }
-  if(!actions.length) {
-    // if no actions are given, guess it's a select
-    actions.push(new Select().add('*'));
-  }
-  if(missingFrom) {
-    targets.push(new From().add(queryNode.table));
-  }
-  return this.visitQueryHelper(actions,targets,filters)
+	this._queryNode = queryNode;
+	// need to sort the top level query nodes on visitation priority
+	// so select/insert/update/delete comes before from comes before where
+	var missingFrom = true;
+	var hasFrom = false;
+	var actions = [];
+	var targets = [];
+	var filters = [];
+	for (var i = 0; i < queryNode.nodes.length; i++) {
+		var node = queryNode.nodes[i];
+		switch (node.type) {
+			case "SELECT":
+			case "DELETE":
+				actions.push(node);
+				break;
+			case "INDEXES":
+			case "INSERT":
+			case "UPDATE":
+			case "CREATE":
+			case "DROP":
+			case "ALTER":
+				actions.push(node);
+				missingFrom = false;
+				break;
+			case "FROM":
+				node.skipFromStatement = hasFrom;
+				hasFrom = true;
+				missingFrom = false;
+				targets.push(node);
+				break;
+			default:
+				filters.push(node);
+				break;
+		}
+	}
+	if (!actions.length) {
+		// if no actions are given, guess it's a select
+		actions.push(new Select().add('*'));
+	}
+	if (missingFrom) {
+		targets.push(new From().add(queryNode.table));
+	}
+	return this.visitQueryHelper(actions, targets, filters)
 };
 
 /**
@@ -577,50 +631,50 @@ Postgres.prototype.visitQuery = function(queryNode) {
  * @param {Node[]} filters
  * @returns {String[]}
  */
-Postgres.prototype.visitQueryHelper=function(actions,targets,filters){
+Postgres.prototype.visitQueryHelper = function(actions, targets, filters) {
 	// lazy-man sorting
 	var sortedNodes = actions.concat(targets).concat(filters);
-	for(var i = 0; i < sortedNodes.length; i++) {
-	  var res = this.visit(sortedNodes[i]);
-	  this.output = this.output.concat(res);
+	for (var i = 0; i < sortedNodes.length; i++) {
+		var res = this.visit(sortedNodes[i]);
+		this.output = this.output.concat(res);
 	}
 	// implicit 'from'
 	return this.output;
 }
 
 Postgres.prototype.visitSubquery = function(queryNode) {
-  // create another query builder of the current class to build the subquery
-  var subQuery = new this._myClass();
+	// create another query builder of the current class to build the subquery
+	var subQuery = new this._myClass();
 
-  // let the subquery modify this instance's params array
-  subQuery.params = this.params;
+	// let the subquery modify this instance's params array
+	subQuery.params = this.params;
 
-  // pass on the disable parameter placeholder flag
-  var previousFlagStatus = subQuery._disableParameterPlaceholders;
-  subQuery._disableParameterPlaceholders = this._disableParameterPlaceholders;
-  try {
-    subQuery.visitQuery(queryNode);
-  } finally {
-    // restore the flag
-    subQuery._disableParameterPlaceholders = previousFlagStatus;
-  }
+	// pass on the disable parameter placeholder flag
+	var previousFlagStatus = subQuery._disableParameterPlaceholders;
+	subQuery._disableParameterPlaceholders = this._disableParameterPlaceholders;
+	try {
+		subQuery.visitQuery(queryNode);
+	} finally {
+		// restore the flag
+		subQuery._disableParameterPlaceholders = previousFlagStatus;
+	}
 
-  var alias = queryNode.alias;
-  return ['(' + subQuery.output.join(' ') + ')' + (alias ? ' ' + alias : '')];
+	var alias = queryNode.alias;
+	return ['(' + subQuery.output.join(' ') + ')' + (alias ? ' ' + alias : '')];
 };
 
 Postgres.prototype.visitTable = function(tableNode) {
-  var table = tableNode.table;
-  var txt="";
-  if(table.getSchema()) {
-    txt = this.quote(table.getSchema());
-    txt += '.';
-  }
-  txt += this.quote(table.getName());
-  if(table.alias) {
-    txt += ' AS ' + this.quote(table.alias);
-  }
-  return [txt];
+	var table = tableNode.table;
+	var txt = "";
+	if (table.getSchema()) {
+		txt = this.quote(table.getSchema());
+		txt += '.';
+	}
+	txt += this.quote(table.getName());
+	if (table.alias) {
+		txt += ' AS ' + this.quote(table.alias);
+	}
+	return [txt];
 };
 
 Postgres.prototype.visitColumn = function(columnNode) {
@@ -735,68 +789,68 @@ Postgres.prototype.visitColumn = function(columnNode) {
 };
 
 Postgres.prototype.visitFunctionCall = function(functionCall) {
-  var txt = functionCall.name + '(' + functionCall.nodes.map(this.visit.bind(this)).join(', ') + ')';
-  return [txt];
+	var txt = functionCall.name + '(' + functionCall.nodes.map(this.visit.bind(this)).join(', ') + ')';
+	return [txt];
 };
 
 Postgres.prototype.visitArrayCall = function(arrayCall) {
-  var txt = 'ARRAY[' + arrayCall.nodes.map(this.visit.bind(this)).join(', ') + ']';
-  return [txt];
+	var txt = 'ARRAY[' + arrayCall.nodes.map(this.visit.bind(this)).join(', ') + ']';
+	return [txt];
 };
 
 Postgres.prototype.visitParameter = function(parameter) {
-  // save the value into the parameters array
-  var value = parameter.value();
-  this.params.push(value);
-  return parameter.isExplicit ? [] : [this._getParameterText(this.params.length, value)];
+	// save the value into the parameters array
+	var value = parameter.value();
+	this.params.push(value);
+	return parameter.isExplicit ? [] : [this._getParameterText(this.params.length, value)];
 };
 
 Postgres.prototype.visitDefault = function(parameter) {
-  /* jshint unused: false */
-  return ['DEFAULT'];
+	/* jshint unused: false */
+	return ['DEFAULT'];
 };
 
 Postgres.prototype.visitAddColumn = function(addColumn) {
-  this._visitingAddColumn = true;
-  var result = ['ADD COLUMN ' + this.visit(addColumn.nodes[0])];
-  this._visitingAddColumn = false;
-  return result;
+	this._visitingAddColumn = true;
+	var result = ['ADD COLUMN ' + this.visit(addColumn.nodes[0])];
+	this._visitingAddColumn = false;
+	return result;
 };
 
 Postgres.prototype.visitDropColumn = function(dropColumn) {
-  return ['DROP COLUMN ' + this.visit(dropColumn.nodes[0])];
+	return ['DROP COLUMN ' + this.visit(dropColumn.nodes[0])];
 };
 
 Postgres.prototype.visitRenameColumn = function(renameColumn) {
-  return ['RENAME COLUMN ' + this.visit(renameColumn.nodes[0]) + ' TO ' + this.visit(renameColumn.nodes[1])];
+	return ['RENAME COLUMN ' + this.visit(renameColumn.nodes[0]) + ' TO ' + this.visit(renameColumn.nodes[1])];
 };
 
 Postgres.prototype.visitRename = function(rename) {
-  return ['RENAME TO ' + this.visit(rename.nodes[0])];
+	return ['RENAME TO ' + this.visit(rename.nodes[0])];
 };
 
 Postgres.prototype.visitIfExists = function() {
-  return ['IF EXISTS'];
+	return ['IF EXISTS'];
 };
 
 Postgres.prototype.visitIfNotExists = function() {
-  return ['IF NOT EXISTS'];
+	return ['IF NOT EXISTS'];
 };
 
 Postgres.prototype.visitCascade = function() {
-  return ['CASCADE'];
+	return ['CASCADE'];
 };
 
 Postgres.prototype.visitRestrict = function() {
-  return ['RESTRICT'];
+	return ['RESTRICT'];
 };
 
 Postgres.prototype.visitForUpdate = function() {
-  return ['FOR UPDATE'];
+	return ['FOR UPDATE'];
 };
 
 Postgres.prototype.visitForShare = function() {
-  return ['FOR SHARE'];
+	return ['FOR SHARE'];
 };
 
 Postgres.prototype.visitJoin = function(join) {
@@ -811,83 +865,83 @@ Postgres.prototype.visitJoin = function(join) {
 };
 
 Postgres.prototype.visitLiteral = function(node) {
-  var txt = [node.literal];
-  if(node.alias) {
-    txt.push(' AS ' + this.quote(node.alias));
-  }
-  return [txt.join('')];
+	var txt = [node.literal];
+	if (node.alias) {
+		txt.push(' AS ' + this.quote(node.alias));
+	}
+	return [txt.join('')];
 };
 
 Postgres.prototype.visitReturning = function(returning) {
-  this.visitingReturning = true;
-  var r = ['RETURNING', returning.nodes.map(this.visit.bind(this)).join(', ')];
-  this.visitingReturning = false;
+	this.visitingReturning = true;
+	var r = ['RETURNING', returning.nodes.map(this.visit.bind(this)).join(', ')];
+	this.visitingReturning = false;
 
-  return r;
+	return r;
 };
 
 Postgres.prototype.visitModifier = function(node) {
-  return [node.type, node.count.type ? this.visit(node.count) : node.count];
+	return [node.type, node.count.type ? this.visit(node.count) : node.count];
 };
 
 Postgres.prototype.visitIndexes = function(node) {
-  /* jshint unused: false */
-  var tableName = this._queryNode.table.getName();
-  var schemaName = this._queryNode.table.getSchema() || "public";
+	/* jshint unused: false */
+	var tableName = this._queryNode.table.getName();
+	var schemaName = this._queryNode.table.getSchema() || "public";
 
-  return [
-    "SELECT relname",
-    "FROM pg_class",
-    "WHERE oid IN (",
-    "SELECT indexrelid",
-    "FROM pg_index, pg_class WHERE pg_class.relname='" + tableName + "'",
-    "AND pg_class.relnamespace IN (SELECT pg_namespace.oid FROM pg_namespace WHERE nspname = '" + schemaName + "')",
-    "AND pg_class.oid=pg_index.indrelid)"
-  ].join(' ');
+	return [
+		"SELECT relname",
+		"FROM pg_class",
+		"WHERE oid IN (",
+		"SELECT indexrelid",
+		"FROM pg_index, pg_class WHERE pg_class.relname='" + tableName + "'",
+		"AND pg_class.relnamespace IN (SELECT pg_namespace.oid FROM pg_namespace WHERE nspname = '" + schemaName + "')",
+		"AND pg_class.oid=pg_index.indrelid)"
+	].join(' ');
 };
 
 Postgres.prototype.visitCreateIndex = function(node) {
-  if (!node.options.columns || (node.options.columns.length === 0)) {
-    throw new Error('No columns defined!');
-  }
+	if (!node.options.columns || (node.options.columns.length === 0)) {
+		throw new Error('No columns defined!');
+	}
 
-  var tableName = this.visit(node.table.toNode());
-  var result    = [ 'CREATE' ];
+	var tableName = this.visit(node.table.toNode());
+	var result = ['CREATE'];
 
-  if (node.options.type) {
-    result.push(node.options.type.toUpperCase());
-  }
+	if (node.options.type) {
+		result.push(node.options.type.toUpperCase());
+	}
 
-  result = result.concat([ 'INDEX', this.quote(node.indexName()) ]);
+	result = result.concat(['INDEX', this.quote(node.indexName())]);
 
-  if (node.options.algorithm) {
-    result.push("USING " + node.options.algorithm.toUpperCase());
-  }
+	if (node.options.algorithm) {
+		result.push("USING " + node.options.algorithm.toUpperCase());
+	}
 
-  result = result.concat([
-    "ON",
-    tableName,
-    "(" + node.options.columns.reduce(function(result, col) {
-      return result.concat(this.quote(col.name));
-    }.bind(this), []) + ")"
-  ]);
+	result = result.concat([
+		"ON",
+		tableName,
+		"(" + node.options.columns.reduce(function(result, col) {
+			return result.concat(this.quote(col.name));
+		}.bind(this), []) + ")"
+	]);
 
-  if (node.options.parser) {
-    result.push("WITH PARSER");
-    result.push(node.options.parser);
-  }
+	if (node.options.parser) {
+		result.push("WITH PARSER");
+		result.push(node.options.parser);
+	}
 
-  return result;
+	return result;
 };
 
 Postgres.prototype.visitDropIndex = function(node) {
-  var result = [ 'DROP INDEX' ];
+	var result = ['DROP INDEX'];
 
-  result.push(this.quote(node.options.indexName));
-  result.push("ON");
-  result.push(this.visit(node.table.toNode()));
+	result.push(this.quote(node.options.indexName));
+	result.push("ON");
+	result.push(this.visit(node.table.toNode()));
 
-  return result;
+	return result;
 };
 
 module.exports = Postgres;

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -264,6 +264,7 @@ Postgres.prototype.visitInsert = function(insert) {
 		}
 	}
 
+	this._visitedInsert = false;
 	return result;
 };
 

--- a/lib/dialect/sqlite.js
+++ b/lib/dialect/sqlite.js
@@ -4,9 +4,9 @@ var util = require('util');
 var assert = require('assert');
 
 var Sqlite = function() {
-  this.output = [];
-  this.params = [];
-  this._hasAddedAColumn = false;
+	this.output = [];
+	this.params = [];
+	this._hasAddedAColumn = false;
 };
 
 var Postgres = require(__dirname + '/postgres');
@@ -18,66 +18,70 @@ Sqlite.prototype._myClass = Sqlite;
 Sqlite.prototype._arrayAggFunctionName = 'GROUP_CONCAT';
 
 Sqlite.prototype._getParameterValue = function(value) {
-  if (Buffer.isBuffer(value)) {
-    value = 'x' + this._getParameterValue(value.toString('hex'));
-  } else {
-    value = Postgres.prototype._getParameterValue.call(this, value);
-  }
-  return value;
+	if (Buffer.isBuffer(value)) {
+		value = 'x' + this._getParameterValue(value.toString('hex'));
+	} else {
+		value = Postgres.prototype._getParameterValue.call(this, value);
+	}
+	return value;
 };
 
 Sqlite.prototype.visitDefault = function() {
-  throw new Error('SQLite requires that all rows of a multi-row insert are for the same columns.');
+	throw new Error('SQLite requires that all rows of a multi-row insert are for the same columns.');
 };
 
 Sqlite.prototype.visitDropColumn = function() {
-  throw new Error('SQLite does not allow dropping columns.');
+	throw new Error('SQLite does not allow dropping columns.');
 };
 
 Sqlite.prototype.visitRenameColumn = function() {
-  throw new Error('SQLite does not allow renaming columns.');
+	throw new Error('SQLite does not allow renaming columns.');
 };
 
 Sqlite.prototype.visitReturning = function() {
-  throw new Error('SQLite does not allow returning clause.');
+	throw new Error('SQLite does not allow returning clause.');
 };
 
 Sqlite.prototype.visitForUpdate = function() {
-  throw new Error('SQLite does not allow FOR UPDATE clause.');
+	throw new Error('SQLite does not allow FOR UPDATE clause.');
+};
+
+Sqlite.prototype.visitOnDuplicateKeyUpdate = function(update) {
+	throw new Error('SQLite does not allow onDuplicate clause.');
 };
 
 Sqlite.prototype.visitForShare = function() {
-  throw new Error('SQLite does not allow FOR SHARE clause.');
+	throw new Error('SQLite does not allow FOR SHARE clause.');
 };
 
 Sqlite.prototype.visitAddColumn = function(addColumn) {
-  assert(!this._hasAddedAColumn, 'SQLite can not add more that one column at a time');
-  var result = Postgres.prototype.visitAddColumn.call(this, addColumn);
-  this._hasAddedAColumn = true;
-  return result;
+	assert(!this._hasAddedAColumn, 'SQLite can not add more that one column at a time');
+	var result = Postgres.prototype.visitAddColumn.call(this, addColumn);
+	this._hasAddedAColumn = true;
+	return result;
 };
 
 Sqlite.prototype.visitIndexes = function(node) {
-  var tableName = this.visit(this._queryNode.table.toNode())[0];
-  return "PRAGMA INDEX_LIST(" + tableName + ")";
+	var tableName = this.visit(this._queryNode.table.toNode())[0];
+	return "PRAGMA INDEX_LIST(" + tableName + ")";
 };
 
 Sqlite.prototype.visitCascade = function() {
-  throw new Error('Sqlite do not support CASCADE in DROP TABLE');
+	throw new Error('Sqlite do not support CASCADE in DROP TABLE');
 };
 
 Sqlite.prototype.visitRestrict = function() {
-  throw new Error('Sqlite do not support RESTRICT in DROP TABLE');
+	throw new Error('Sqlite do not support RESTRICT in DROP TABLE');
 };
 
 Sqlite.prototype.visitBinary = function(binary) {
-  if(binary.operator === '@@'){
-    binary.operator = 'MATCH';
-    var ret = Sqlite.super_.prototype.visitBinary.call(this, binary);
-    binary.operator = '@@';
-    return ret;
-  }
-  return Sqlite.super_.prototype.visitBinary.call(this, binary);
+	if (binary.operator === '@@') {
+		binary.operator = 'MATCH';
+		var ret = Sqlite.super_.prototype.visitBinary.call(this, binary);
+		binary.operator = '@@';
+		return ret;
+	}
+	return Sqlite.super_.prototype.visitBinary.call(this, binary);
 }
 
 module.exports = Sqlite;

--- a/lib/node/onDuplicateKeyUpdate.js
+++ b/lib/node/onDuplicateKeyUpdate.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var Node = require(__dirname);
+
+module.exports = Node.define({
+	type: 'ON DUPLICATE KEY UPDATE'
+});

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -2,226 +2,240 @@
 
 var assert = require('assert');
 var sliced = require('sliced');
-var util   = require('util');
+var util = require('util');
 
-var Node            = require('./');
-var Select          = require('./select');
-var From            = require('./from');
-var Where           = require('./where');
-var OrderBy         = require('./orderBy');
-var GroupBy         = require('./groupBy');
-var Having          = require('./having');
-var Insert          = require('./insert');
-var Update          = require('./update');
-var Delete          = require('./delete');
-var Returning       = require('./returning');
-var ForUpdate       = require('./forUpdate');
-var ForShare        = require('./forShare');
-var Create          = require('./create');
-var Drop            = require('./drop');
-var Alter           = require('./alter');
-var AddColumn       = require('./addColumn');
-var DropColumn      = require('./dropColumn');
-var RenameColumn    = require('./renameColumn');
-var Rename          = require('./rename');
-var Column          = require('../column');
-var ParameterNode   = require('./parameter');
+var Node = require('./');
+var Select = require('./select');
+var From = require('./from');
+var Where = require('./where');
+var OrderBy = require('./orderBy');
+var GroupBy = require('./groupBy');
+var Having = require('./having');
+var Insert = require('./insert');
+var Update = require('./update');
+var OnDuplicateKeyUpdate = require('./onDuplicateKeyUpdate');
+var Delete = require('./delete');
+var Returning = require('./returning');
+var ForUpdate = require('./forUpdate');
+var ForShare = require('./forShare');
+var Create = require('./create');
+var Drop = require('./drop');
+var Alter = require('./alter');
+var AddColumn = require('./addColumn');
+var DropColumn = require('./dropColumn');
+var RenameColumn = require('./renameColumn');
+var Rename = require('./rename');
+var Column = require('../column');
+var ParameterNode = require('./parameter');
 var PrefixUnaryNode = require('./prefixUnary');
-var IfExists        = require('./ifExists');
-var IfNotExists     = require('./ifNotExists');
-var Cascade         = require('./cascade');
-var Restrict        = require('./restrict');
-var Indexes         = require('./indexes');
-var CreateIndex     = require('./createIndex');
-var DropIndex       = require('./dropIndex');
-var Table           = require('./table');
+var IfExists = require('./ifExists');
+var IfNotExists = require('./ifNotExists');
+var Cascade = require('./cascade');
+var Restrict = require('./restrict');
+var Indexes = require('./indexes');
+var CreateIndex = require('./createIndex');
+var DropIndex = require('./dropIndex');
+var Table = require('./table');
 
 var Modifier = Node.define({
-  constructor: function(table, type, count) {
-    this.table = table;
-    this.type = type;
-    this.count = count;
-  }
+	constructor: function(table, type, count) {
+		this.table = table;
+		this.type = type;
+		this.count = count;
+	}
 });
 
 // get the first element of an arguments if it is an array, else return arguments as an array
 var getArrayOrArgsAsArray = function(args) {
-  if (util.isArray(args[0])) {
-    return args[0];
-  }
-  return sliced(args);
+	if (util.isArray(args[0])) {
+		return args[0];
+	}
+	return sliced(args);
 };
 
 var Query = Node.define({
-  type: 'QUERY',
+	type: 'QUERY',
 
-  constructor: function(table) {
-    Node.call(this);
-    this.table = table;
-    if (table) {
-      this.sql = table.sql;
-    }
-  },
+	constructor: function(table) {
+		Node.call(this);
+		this.table = table;
+		if (table) {
+			this.sql = table.sql;
+		}
+	},
 
-  select: function() {
-    var select;
-    if (this._select) {
-      select = this._select;
-    } else {
-      select = this._select = new Select();
-      this.add(select);
-    }
+	select: function() {
+		var select;
+		if (this._select) {
+			select = this._select;
+		} else {
+			select = this._select = new Select();
+			this.add(select);
+		}
 
-    //allow things like .select(a.star(), [ a.id, a.name ])
-    //this will flatten them into a single array
-    var args = sliced(arguments).reduce(function(cur, next) {
-      if (util.isArray(next)) {
-        return cur.concat(next);
-      }
+		//allow things like .select(a.star(), [ a.id, a.name ])
+		//this will flatten them into a single array
+		var args = sliced(arguments).reduce(function(cur, next) {
+			if (util.isArray(next)) {
+				return cur.concat(next);
+			}
 
-      cur.push(next);
-      return cur;
-    }, []);
+			cur.push(next);
+			return cur;
+		}, []);
 
-    select.addAll(args);
+		select.addAll(args);
 
-    // if this is a subquery then add reference to this column
-    if (this.type === 'SUBQUERY') {
-      for (var j = 0; j < select.nodes.length; j++) {
-        var name = select.nodes[j].alias || select.nodes[j].name;
-        var col = new Column(select.nodes[j]);
-        col.name = name;
-        col.property = name;
-        col.table = this;
-        if (this[name] === undefined) {
-          this[name] = col;
-        }
-      }
-    }
-    return this;
-  },
+		// if this is a subquery then add reference to this column
+		if (this.type === 'SUBQUERY') {
+			for (var j = 0; j < select.nodes.length; j++) {
+				var name = select.nodes[j].alias || select.nodes[j].name;
+				var col = new Column(select.nodes[j]);
+				col.name = name;
+				col.property = name;
+				col.table = this;
+				if (this[name] === undefined) {
+					this[name] = col;
+				}
+			}
+		}
+		return this;
+	},
 
-  star: function() {
-    assert(this.type === 'SUBQUERY', 'star() can only be used on a subQuery');
-    return new Column({
-      table: this,
-      star: true
-    });
-  },
+	star: function() {
+		assert(this.type === 'SUBQUERY', 'star() can only be used on a subQuery');
+		return new Column({
+			table: this,
+			star: true
+		});
+	},
 
-  from: function() {
-    var tableNodes = arguments;
+	from: function() {
+		var tableNodes = arguments;
 
-    if (Array.isArray(arguments[0])) {
-      tableNodes = arguments[0];
-    }
+		if (Array.isArray(arguments[0])) {
+			tableNodes = arguments[0];
+		}
 
-    for (var i=0; i<tableNodes.length; i++) {
-      this.add(new From().add(tableNodes[i]));
-    }
+		for (var i = 0; i < tableNodes.length; i++) {
+			this.add(new From().add(tableNodes[i]));
+		}
 
-    return this;
-  },
+		return this;
+	},
 
-  where: function(node) {
-    if (arguments.length > 1) {
-      // allow multiple where clause arguments
-      var args = sliced(arguments);
-      for (var i = 0; i < args.length; i++) {
-        this.where(args[i]);
-      }
-      return this;
-    }
-    // calling #where twice functions like calling #where & then #and
-    if (this.whereClause) {
-      return this.and(node);
-    }
-    this.whereClause = new Where(this.table);
-    this.whereClause.add(node);
-    return this.add(this.whereClause);
-  },
+	where: function(node) {
+		if (arguments.length > 1) {
+			// allow multiple where clause arguments
+			var args = sliced(arguments);
+			for (var i = 0; i < args.length; i++) {
+				this.where(args[i]);
+			}
+			return this;
+		}
+		// calling #where twice functions like calling #where & then #and
+		if (this.whereClause) {
+			return this.and(node);
+		}
+		this.whereClause = new Where(this.table);
+		this.whereClause.add(node);
+		return this.add(this.whereClause);
+	},
 
-  or: function(node) {
-    if (!this.whereClause) return this.where(node);
-    this.whereClause.or(node);
-    return this;
-  },
+	or: function(node) {
+		if (!this.whereClause) return this.where(node);
+		this.whereClause.or(node);
+		return this;
+	},
 
-  and: function(node) {
-    if (!this.whereClause) return this.where(node);
-    this.whereClause.and(node);
-    return this;
-  },
+	and: function(node) {
+		if (!this.whereClause) return this.where(node);
+		this.whereClause.and(node);
+		return this;
+	},
 
-  order: function() {
-    var args = getArrayOrArgsAsArray(arguments);
-    var orderBy;
-    if (this._orderBy) {
-      orderBy = this._orderBy;
-    } else {
-      orderBy = this._orderBy = new OrderBy();
-      this.add(orderBy);
-    }
-    orderBy.addAll(args);
-    return this;
-  },
+	order: function() {
+		var args = getArrayOrArgsAsArray(arguments);
+		var orderBy;
+		if (this._orderBy) {
+			orderBy = this._orderBy;
+		} else {
+			orderBy = this._orderBy = new OrderBy();
+			this.add(orderBy);
+		}
+		orderBy.addAll(args);
+		return this;
+	},
 
-  group: function() {
-    var args = getArrayOrArgsAsArray(arguments);
-    var groupBy = new GroupBy().addAll(args);
-    return this.add(groupBy);
-  },
+	group: function() {
+		var args = getArrayOrArgsAsArray(arguments);
+		var groupBy = new GroupBy().addAll(args);
+		return this.add(groupBy);
+	},
 
-  having: function() {
-    var args = getArrayOrArgsAsArray(arguments);
-    var having = new Having().addAll(args);
-    return this.add(having);
-  },
+	having: function() {
+		var args = getArrayOrArgsAsArray(arguments);
+		var having = new Having().addAll(args);
+		return this.add(having);
+	},
 
-  insert: function(o) {
-    var self = this;
+	insert: function(o) {
+		var self = this;
 
-    var args = sliced(arguments);
-    // object literal
-    if (arguments.length === 1 && !o.toNode && !o.forEach) {
-      args = [];
-      Object.keys(o).forEach(function(key) {
-        var col = self.table.get(key);
-        if(col && !col.autoGenerated)
-          args.push(col.value(o[key]));
-      });
-    } else if (o.forEach) {
-      o.forEach(function(arg) {
-        return self.insert.call(self, arg);
-      });
-      return self;
-    }
+		var args = sliced(arguments);
+		// object literal
+		if (arguments.length === 1 && !o.toNode && !o.forEach) {
+			args = [];
+			Object.keys(o).forEach(function(key) {
+				var col = self.table.get(key);
+				if (col && !col.autoGenerated)
+					args.push(col.value(o[key]));
+			});
+		} else if (o.forEach) {
+			o.forEach(function(arg) {
+				return self.insert.call(self, arg);
+			});
+			return self;
+		}
 
-    if (self.insertClause) {
-      self.insertClause.add(args);
-      return self;
-    } else {
-      self.insertClause = new Insert();
-      self.insertClause.add(args);
-      return self.add(self.insertClause);
-    }
+		if (self.insertClause) {
+			self.insertClause.add(args);
+			return self;
+		} else {
+			self.insertClause = new Insert();
+			self.insertClause.add(args);
+			return self.add(self.insertClause);
+		}
 
-  },
+	},
 
-  update: function(o) {
-    var self = this;
-    var update = new Update();
-    Object.keys(o).forEach(function(key) {
-      var col = self.table.get(key);
-      if(col && !col.autoGenerated) {
-        var val = o[key];
-        update.add(col.value(ParameterNode.getNodeOrParameterNode(val)));
-      }
-    });
-    return this.add(update);
-  },
+	update: function(o) {
+		var self = this;
+		var update = new Update();
+		Object.keys(o).forEach(function(key) {
+			var col = self.table.get(key);
+			if (col && !col.autoGenerated) {
+				var val = o[key];
+				update.add(col.value(ParameterNode.getNodeOrParameterNode(val)));
+			}
+		});
+		return this.add(update);
+	},
 
-  parameter: function(v) {
+	onDuplicateKeyUpdate: function(o) {
+		var self = this;
+		var onDuplicateKeyUpdate = new OnDuplicateKeyUpdate();
+		Object.keys(o).forEach(function(key) {
+			var col = self.table.get(key);
+			if (col && !col.autoGenerated) {
+				var val = o[key];
+				onDuplicateKeyUpdate.add(col.value(ParameterNode.getNodeOrParameterNode(val)));
+			}
+		});
+		return this.add(onDuplicateKeyUpdate);
+	},
+
+	parameter: function(v) {
 		var param = ParameterNode.getNodeOrParameterNode(v);
 		param.isExplicit = true;
 		return this.add(param);

--- a/lib/table.js
+++ b/lib/table.js
@@ -26,108 +26,112 @@ var Table = function(config) {
 };
 
 Table.define = function(config) {
-  var table = new Table(config);
-  // allow hash of columns as well as array
-  if (config.columns && !util.isArray(config.columns)) {
-    var cols = [];
+	var table = new Table(config);
+	// allow hash of columns as well as array
+	if (config.columns && !util.isArray(config.columns)) {
+		var cols = [];
 
-    for (var key in config.columns) {
-      if (config.columns.hasOwnProperty(key)) {
-        var col = config.columns[key];
-        col.name = key;
-        cols.push(col);
-      }
-    }
+		for (var key in config.columns) {
+			if (config.columns.hasOwnProperty(key)) {
+				var col = config.columns[key];
+				col.name = key;
+				cols.push(col);
+			}
+		}
 
-    config.columns = cols;
-  }
+		config.columns = cols;
+	}
 
-  for (var i = 0; i < config.columns.length; i++) {
-    table.addColumn(config.columns[i]);
-  }
-  return table;
+	for (var i = 0; i < config.columns.length; i++) {
+		table.addColumn(config.columns[i]);
+	}
+	return table;
 };
 
 Table.prototype.clone = function(config) {
-  return Table.define(lodash.extend({
-    schema: this._schema,
-    name: this._name,
-    sql: this.sql,
-    columnWhiteList: !!this.columnWhiteList,
-    snakeToCamel: !!this.snakeToCamel,
-    columns: this.columns
-  }, config || {}));
+	return Table.define(lodash.extend({
+		schema: this._schema,
+		name: this._name,
+		sql: this.sql,
+		columnWhiteList: !!this.columnWhiteList,
+		snakeToCamel: !!this.snakeToCamel,
+		columns: this.columns
+	}, config || {}));
 };
 
 Table.prototype.createColumn = function(col) {
-  if(!(col instanceof Column)) {
-    if(typeof col === 'string') {
-      col = { name: col };
-    }
+	if (!(col instanceof Column)) {
+		if (typeof col === 'string') {
+			col = {
+				name: col
+			};
+		}
 
-    col.table = this;
-    col = new Column(col);
-  }
+		col.table = this;
+		col = new Column(col);
+	}
 
-  return col;
+	return col;
 };
 
 Table.prototype.addColumn = function(col, options) {
-  col     = this.createColumn(col);
-  options = lodash.extend({
-    noisy: true
-  }, options || {});
+	col = this.createColumn(col);
+	options = lodash.extend({
+		noisy: true
+	}, options || {});
 
-  if(this.hasColumn(col)) {
-    if (options.noisy) {
-      throw new Error('Table ' + this._name + ' already has column or property by the name of ' + col.name);
-    } else {
-      return this;
-    }
-  } else if(!!this[col.name] && (process.env.NODE_ENV !== 'test')) {
-    console.log('Please notice that you have just defined the column "' + col.name + '". In order to access it, you need to use "table.getColumn(\'' + col.name + '\');"!');
-  }
-  this.columns.push(col);
+	if (this.hasColumn(col)) {
+		if (options.noisy) {
+			throw new Error('Table ' + this._name + ' already has column or property by the name of ' + col.name);
+		} else {
+			return this;
+		}
+	} else if (!!this[col.name] && (process.env.NODE_ENV !== 'test')) {
+		console.log('Please notice that you have just defined the column "' + col.name + '". In order to access it, you need to use "table.getColumn(\'' + col.name + '\');"!');
+	}
+	this.columns.push(col);
 
-  function snakeToCamel(snakeName) {
-    return snakeName.replace(/[\-_]([a-z])/g, function(m, $1){ return $1.toUpperCase(); });
-  }
+	function snakeToCamel(snakeName) {
+		return snakeName.replace(/[\-_]([a-z])/g, function(m, $1) {
+			return $1.toUpperCase();
+		});
+	}
 
-  var property = col.property = col.property || (this.snakeToCamel ? snakeToCamel(col.name) : col.name);
-  this[property] = this[property] || col;
-  return this;
+	var property = col.property = col.property || (this.snakeToCamel ? snakeToCamel(col.name) : col.name);
+	this[property] = this[property] || col;
+	return this;
 };
 
 Table.prototype.hasColumn = function(col) {
-  col = this.createColumn(col);
+	col = this.createColumn(col);
 
-  var cols = this.columns.filter(function(column) {
-    return column.property === col.property || column.name === col.name;
-  });
+	var cols = this.columns.filter(function(column) {
+		return column.property === col.property || column.name === col.name;
+	});
 
-  return cols.length > 0;
+	return cols.length > 0;
 };
 
 Table.prototype.getColumn =
-Table.prototype.get =
-function(colName) {
-  for(var i = 0; i < this.columns.length; i++) {
-    var col = this.columns[i];
-    if (colName === col.property || colName === col.name) {
-      return col;
-    }
-  }
-  if(this.columnWhiteList)
-    return null;
-  throw new Error('Table ' + this._name + ' does not have a column or property named ' + colName);
-};
+	Table.prototype.get =
+	function(colName) {
+		for (var i = 0; i < this.columns.length; i++) {
+			var col = this.columns[i];
+			if (colName === col.property || colName === col.name) {
+				return col;
+			}
+		}
+		if (this.columnWhiteList)
+			return null;
+		throw new Error('Table ' + this._name + ' does not have a column or property named ' + colName);
+	};
 
 Table.prototype.getSchema = function() {
-  return this._schema;
+	return this._schema;
 };
 
 Table.prototype.setSchema = function(schema) {
-  this._schema = schema;
+	this._schema = schema;
 };
 
 Table.prototype.getName = function() {
@@ -136,145 +140,157 @@ Table.prototype.getName = function() {
 };
 
 Table.prototype.star = function(options) {
-  options = options || {};
-  if (options.prefix) {
-    return this.columns.map(function(column) {
-      return this[column.name].as(options.prefix + column.name);
-    }.bind(this));
-  }
+	options = options || {};
+	if (options.prefix) {
+		return this.columns.map(function(column) {
+			return this[column.name].as(options.prefix + column.name);
+		}.bind(this));
+	}
 
-  return new Column({table: this, star: true});
+	return new Column({
+		table: this,
+		star: true
+	});
 };
 
 Table.prototype.literal = function(literal) {
-  return new LiteralNode(literal);
+	return new LiteralNode(literal);
 };
 
 Table.prototype.count = function(alias) {
-  var name = this.alias || this._name,
-    col = new Column({table: this, star: true});
-  // ColumnNode
-  return col.count(alias || name + '_count');
+	var name = this.alias || this._name,
+		col = new Column({
+			table: this,
+			star: true
+		});
+	// ColumnNode
+	return col.count(alias || name + '_count');
 };
 
 Table.prototype.select = function() {
-  // create the query and pass it off
-  var query = new Query(this);
-  if (arguments.length === 0) {
-    query.select.call(query, this.star());
-  } else {
-    query.select.apply(query, arguments);
-  }
-  return query;
+	// create the query and pass it off
+	var query = new Query(this);
+	if (arguments.length === 0) {
+		query.select.call(query, this.star());
+	} else {
+		query.select.apply(query, arguments);
+	}
+	return query;
 };
 
 Table.prototype.from = function() {
-  var query = new Query(this);
-  query.from.apply(query, arguments);
-  return query;
+	var query = new Query(this);
+	query.from.apply(query, arguments);
+	return query;
 };
 
 Table.prototype.subQuery = function(alias) {
-  // create the query and pass it off
-  var query = new Query(this);
-  query.type = 'SUBQUERY';
-  query.alias = alias;
-  query.join = function(other) {
-    return new JoinNode('INNER', this.toNode(), other.toNode(), other);
-  };
-  return query;
+	// create the query and pass it off
+	var query = new Query(this);
+	query.type = 'SUBQUERY';
+	query.alias = alias;
+	query.join = function(other) {
+		return new JoinNode('INNER', this.toNode(), other.toNode(), other);
+	};
+	return query;
 };
 
 Table.prototype.insert = function() {
-  var query = new Query(this);
-  if(arguments[0].length == 0){
-    query.select.call(query, this.star());
-    query.where.apply(query,["1=2"]);
-  } else {
-    query.insert.apply(query, arguments);
-  }
-  return query;
+	var query = new Query(this);
+	if (arguments[0].length == 0) {
+		query.select.call(query, this.star());
+		query.where.apply(query, ["1=2"]);
+	} else {
+		query.insert.apply(query, arguments);
+	}
+	return query;
 };
 
 Table.prototype.update = function() {
-  var query = new Query(this);
-  query.update.apply(query, arguments);
-  return query;
+	var query = new Query(this);
+	query.update.apply(query, arguments);
+	return query;
+};
+
+Table.prototype.onDuplicateKeyUpdate = function() {
+	var query = new Query(this);
+	query.onDuplicateKeyUpdate.apply(query, arguments);
+	return query;
 };
 
 Table.prototype['delete'] = function() {
-  var query = new Query(this);
-  query['delete'].apply(query, arguments);
-  return query;
+	var query = new Query(this);
+	query['delete'].apply(query, arguments);
+	return query;
 };
 
 Table.prototype.create = function() {
-  var query = new Query(this);
-  query.create.apply(query, arguments);
-  return query;
+	var query = new Query(this);
+	query.create.apply(query, arguments);
+	return query;
 };
 
 Table.prototype.drop = function() {
-  var query = new Query(this);
-  query.drop.apply(query, arguments);
-  return query;
+	var query = new Query(this);
+	query.drop.apply(query, arguments);
+	return query;
 };
 
 Table.prototype.alter = function() {
-  var query = new Query(this);
-  query.alter.apply(query, arguments);
-  return query;
+	var query = new Query(this);
+	query.alter.apply(query, arguments);
+	return query;
 };
 
 Table.prototype.toNode = function() {
-  return new TableNode(this);
+	return new TableNode(this);
 };
 
 Table.prototype.join = function(other) {
-  return new JoinNode('INNER', this.toNode(), other.toNode(), other);
+	return new JoinNode('INNER', this.toNode(), other.toNode(), other);
 };
 
 Table.prototype.leftJoin = function(other) {
-  return new JoinNode('LEFT', this.toNode(), other.toNode());
+	return new JoinNode('LEFT', this.toNode(), other.toNode());
 };
 
 // auto-join tables based on column intropsection
 Table.prototype.joinTo = function(other) {
-  return Joiner.leftJoin(this, other);
+	return Joiner.leftJoin(this, other);
 };
 
 Table.prototype.as = function(alias) {
-  // TODO could this be cleaner?
-  var t = Table.define(this._initialConfig);
-  t.alias = alias;
-  return t;
+	// TODO could this be cleaner?
+	var t = Table.define(this._initialConfig);
+	t.alias = alias;
+	return t;
 };
 
 // called in shorthand when not calling select
 Table.prototype.__defineGetter__("nodes", function() {
-  return this.select(this.star()).nodes;
+	return this.select(this.star()).nodes;
 });
 
 Table.prototype.where = function() {
-  var query = new Query(this);
-  query.where.apply(query, arguments);
-  return query;
+	var query = new Query(this);
+	query.where.apply(query, arguments);
+	return query;
 };
 
 Table.prototype.and = function() {
-  var query = new Query(this);
-  query.where.apply(query, arguments);
-  return query;
+	var query = new Query(this);
+	query.where.apply(query, arguments);
+	return query;
 };
 
 Table.prototype.or = function() {
-  var query = new Query(this);
-  query.or.apply(query, arguments);
-  return query;
+	var query = new Query(this);
+	query.or.apply(query, arguments);
+	return query;
 };
 
 Table.prototype.indexes = function() {
-  return new Query(this).indexes();
+	return new Query(this).indexes();
 };
 
 module.exports = Table;

--- a/test/dialects/insert-duplicate-update-tests.js
+++ b/test/dialects/insert-duplicate-update-tests.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var Harness = require('./support');
+var post = Harness.definePostTable();
+var user = Harness.defineUserTable();
+
+
+Harness.test({
+	query: post.insert({
+		content: 'test',
+		userId: 2
+	}).onDuplicateKeyUpdate({
+		content: 'test123'
+	}),
+	pg: {
+		throws: true
+	},
+	sqlite: {
+		throws: true
+	},
+	mysql: {
+		text: 'INSERT INTO `post` (`content`, `userId`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `content` = ?',
+		string: 'INSERT INTO `post` (`content`, `userId`) VALUES (\'test\', 2) ON DUPLICATE KEY UPDATE `content` = \'test123\''
+	},
+	mssql: {
+		throws: true
+	},
+	params: ['test', 2, 'test123']
+});

--- a/test/dialects/support.js
+++ b/test/dialects/support.js
@@ -33,6 +33,7 @@ module.exports = {
 						var compiledQuery = new DialectClass().getQuery(expected.query);
 
 						// test result is correct
+						var expectedText = expectedObject.text || expectedObject;
 						assert.equal(compiledQuery.text, expectedText);
 
 						// if params are specified then test these are correct

--- a/test/dialects/support.js
+++ b/test/dialects/support.js
@@ -5,112 +5,121 @@ var Table = require('../../lib/table');
 
 // specify dialect classes
 var dialects = {
-  pg     : require('../../lib/dialect/postgres'),
-  sqlite : require('../../lib/dialect/sqlite'),
-  mysql  : require('../../lib/dialect/mysql'),
-  mssql  : require('../../lib/dialect/mssql')
+	pg: require('../../lib/dialect/postgres'),
+	sqlite: require('../../lib/dialect/sqlite'),
+	mysql: require('../../lib/dialect/mysql'),
+	mssql: require('../../lib/dialect/mssql')
 };
 
 module.exports = {
-  test: function(expected) {
-    // for each dialect
-    Object.keys(dialects).forEach(function(dialect) {
-      var expectedObject = expected[dialect];
-      if (undefined !== expectedObject) {
+	test: function(expected) {
+		// for each dialect
+		Object.keys(dialects).forEach(function(dialect) {
+			var expectedObject = expected[dialect];
+			if (undefined !== expectedObject) {
 
-        var DialectClass = dialects[dialect];
+				var DialectClass = dialects[dialect];
 
-        var title = dialect + ': ' + (expected.title || expectedObject.text || expectedObject);
-        test(title, function() {
+				var title = dialect + ': ' + (expected.title || expectedObject.text || expectedObject);
+				test(title, function() {
 
-          // check if this query is expected to throw
-          if (expectedObject.throws) {
-            assert.throws(function() {
-              new DialectClass().getQuery(expected.query);
-            });
-          } else {
-            // build query for dialect
-            var compiledQuery = new DialectClass().getQuery(expected.query);
+					// check if this query is expected to throw
+					if (expectedObject.throws) {
+						assert.throws(function() {
+							new DialectClass().getQuery(expected.query);
+						});
+					} else {
+						// build query for dialect
+						var compiledQuery = new DialectClass().getQuery(expected.query);
 
-            // test result is correct
-            var expectedText = expectedObject.text || expectedObject;
-            assert.equal(compiledQuery.text, expectedText);
+						// test result is correct
+						assert.equal(compiledQuery.text, expectedText);
 
-            // if params are specified then test these are correct
-            var expectedParams = expectedObject.params || expected.params;
-            if (undefined !== expectedParams) {
-              assert.equal(expectedParams.length, compiledQuery.values.length, 'params length');
-              for (var i = 0; i < expectedParams.length; i++) {
-                assert.deepEqual(expectedParams[i], compiledQuery.values[i], 'param ' + (i + 1));
-              }
-            }
-          }
+						// if params are specified then test these are correct
+						var expectedParams = expectedObject.params || expected.params;
+						if (undefined !== expectedParams) {
+							assert.equal(expectedParams.length, compiledQuery.values.length, 'params length');
+							for (var i = 0; i < expectedParams.length; i++) {
+								assert.deepEqual(expectedParams[i], compiledQuery.values[i], 'param ' + (i + 1));
+							}
+						}
+					}
 
-          if (undefined !== expectedObject.string) {
-            // test the toString
-            if (expectedObject.throws) {
-              assert.throws(function() {
-                new DialectClass().getString(expected.query);
-              });
-            } else {
-              var compiledString = new DialectClass().getString(expected.query);
+					if (undefined !== expectedObject.string) {
+						// test the toString
+						if (expectedObject.throws) {
+							assert.throws(function() {
+								new DialectClass().getString(expected.query);
+							});
+						} else {
+							var compiledString = new DialectClass().getString(expected.query);
 
-              // test result is correct
-              assert.equal(compiledString, expectedObject.string);
-            }
-          }
-        });
-      } // if
-    }); // forEach
-  },
+							// test result is correct
+							assert.equal(compiledString, expectedObject.string);
+						}
+					}
+				});
+			} // if
+		}); // forEach
+	},
 
-  defineUserTable: function() {
-    return Table.define({
-      name: 'user',
-      quote: true,
-      columns: ['id', 'name']
-    });
-  },
+	defineUserTable: function() {
+		return Table.define({
+			name: 'user',
+			quote: true,
+			columns: ['id', 'name']
+		});
+	},
 
-  definePostTable: function() {
-    return Table.define({
-      name: 'post',
-      columns: ['id', 'userId', 'content', 'tags']
-    });
-  },
+	definePostTable: function() {
+		return Table.define({
+			name: 'post',
+			columns: ['id', 'userId', 'content', 'tags']
+		});
+	},
 
-  defineCommentTable: function() {
-    return Table.define({
-      name: 'comment',
-      columns: ['postId', 'text']
-    });
-  },
+	defineCommentTable: function() {
+		return Table.define({
+			name: 'comment',
+			columns: ['postId', 'text']
+		});
+	},
 
-  defineCustomerTable: function() {
-    return Table.define({
-      name: 'customer',
-      columns: ['id', 'name', 'age', 'income', 'metadata']
-    });
-  },
+	defineCustomerTable: function() {
+		return Table.define({
+			name: 'customer',
+			columns: ['id', 'name', 'age', 'income', 'metadata']
+		});
+	},
 
-  defineCustomerAliasTable: function() {
-    return Table.define({
-      name: 'customer',
-      columns: {
-        id: {property: 'id_alias'},
-        name: {property: 'name_alias'},
-        age: {property: 'age_alias'},
-        income: {property: 'income_alias'},
-        metadata: {property: 'metadata_alias'}
-      }
-    });
-  },
+	defineCustomerAliasTable: function() {
+		return Table.define({
+			name: 'customer',
+			columns: {
+				id: {
+					property: 'id_alias'
+				},
+				name: {
+					property: 'name_alias'
+				},
+				age: {
+					property: 'age_alias'
+				},
+				income: {
+					property: 'income_alias'
+				},
+				metadata: {
+					property: 'metadata_alias'
+				}
+			}
+		});
+	},
 
-  // This table contains column names that correspond to popularly used variables in formulas.
-  defineVariableTable: function() {
-    return Table.define({
-      name: 'variable',
-      columns: ['a', 'b', 'c', 'd', 't', 'u', 'v', 'x', 'y', 'z']
-    });
-  }
+	// This table contains column names that correspond to popularly used variables in formulas.
+	defineVariableTable: function() {
+		return Table.define({
+			name: 'variable',
+			columns: ['a', 'b', 'c', 'd', 't', 'u', 'v', 'x', 'y', 'z']
+		});
+	}
 };


### PR DESCRIPTION
Hi,

I have added support for 'ON DUPLICATE KEY UPDATE' clause for insert in mysql. For other dialects, it has been handled. It can be used while making query as follows:
var query = table.insert({
		name: "pro1",
		full_name: "provider1",
		product_id: 5400
	}).onDuplicateKeyUpdate({
		is_enabled: 1,
		product_id: 5401
	});

As of now, this clause can only accept assignment operation (like product_id = 5401) and no arithmetic operation (like product_id = product_id + 1).

Due to some text editor formatting changes, the diff is huge. I am very sorry for that. I should have kept that in mind. Please verify the changes and let me know your feedback.