### PR TITLE
Added TRUNCATE TABLE command.

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -107,6 +107,7 @@ Postgres.prototype.visit = function(node) {
     case 'DELETE'          : return this.visitDelete(node);
     case 'CREATE'          : return this.visitCreate(node);
     case 'DROP'            : return this.visitDrop(node);
+    case 'TRUNCATE'        : return this.visitTruncate(node);
     case 'ALIAS'           : return this.visitAlias(node);
     case 'ALTER'           : return this.visitAlter(node);
     case 'CAST'            : return this.visitCast(node);
@@ -277,6 +278,12 @@ Postgres.prototype.visitDrop = function(drop) {
   // don't auto-generate from clause
   var result = ['DROP TABLE'];
   result = result.concat(drop.nodes.map(this.visit.bind(this)));
+  return result;
+};
+
+Postgres.prototype.visitTruncate = function(truncate) {
+  var result = ['TRUNCATE TABLE'];
+  result = result.concat(truncate.nodes.map(this.visit.bind(this)));
   return result;
 };
 
@@ -545,6 +552,7 @@ Postgres.prototype.visitQuery = function(queryNode) {
       case "UPDATE":
       case "CREATE":
       case "DROP":
+      case "TRUNCATE":
       case "ALTER":
         actions.push(node);
         missingFrom = false;

--- a/lib/dialect/sqlite.js
+++ b/lib/dialect/sqlite.js
@@ -34,6 +34,12 @@ Sqlite.prototype.visitDropColumn = function() {
   throw new Error('SQLite does not allow dropping columns.');
 };
 
+Sqlite.prototype.visitTruncate = function(truncate) {
+  var result = ['DELETE FROM'];
+  result = result.concat(truncate.nodes.map(this.visit.bind(this)));
+  return result;
+};
+
 Sqlite.prototype.visitRenameColumn = function() {
   throw new Error('SQLite does not allow renaming columns.');
 };

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -20,6 +20,7 @@ var ForUpdate       = require('./forUpdate');
 var ForShare        = require('./forShare');
 var Create          = require('./create');
 var Drop            = require('./drop');
+var Truncate        = require('./truncate');
 var Alter           = require('./alter');
 var AddColumn       = require('./addColumn');
 var DropColumn      = require('./dropColumn');
@@ -305,6 +306,10 @@ var Query = Node.define({
     } else {
       return this.add(new Drop(this.table));
     }
+  },
+
+  truncate: function() {
+    return this.add(new Truncate(this.table));
   },
 
   alter: function() {

--- a/lib/node/truncate.js
+++ b/lib/node/truncate.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var Node = require(__dirname);
+
+module.exports = Node.define({
+  type: 'TRUNCATE',
+
+  constructor: function(table) {
+  	Node.call(this);
+  	this.add(table);
+  }
+});

--- a/lib/table.js
+++ b/lib/table.js
@@ -234,6 +234,12 @@ Table.prototype.drop = function() {
   return query;
 };
 
+Table.prototype.truncate = function() {
+  var query = new Query(this);
+  query.truncate.apply(query, arguments);
+  return query;
+};
+
 Table.prototype.alter = function() {
   var query = new Query(this);
   query.alter.apply(query, arguments);

--- a/test/dialects/truncate-table-tests.js
+++ b/test/dialects/truncate-table-tests.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var Harness = require('./support');
+var post = Harness.definePostTable();
+
+Harness.test({
+  query: post.truncate(),
+  pg: {
+    text  : 'TRUNCATE TABLE "post"',
+    string: 'TRUNCATE TABLE "post"'
+  },
+  sqlite: {
+    text  : 'DELETE FROM "post"',
+    string: 'DELETE FROM "post"'
+  },
+  mysql: {
+    text  : 'TRUNCATE TABLE `post`',
+    string: 'TRUNCATE TABLE `post`'
+  },
+  mssql: {
+    text  : 'TRUNCATE TABLE [post]',
+    string: 'TRUNCATE TABLE [post]'
+  },
+  params: []
+});


### PR DESCRIPTION
Adds the TRUNCATE TABLE command. I believe I have the syntax is correct for all currently supported databases. Generates
```
TRUNCATE TABLE name
````
Where name is appropriately quoted for the engine. For PostgreSQL, MySQL, Microsoft SQL. For SQLite it generates
```
DELETE FROM name
```
since SQLite doesn't have a TRUNCATE command.