### PR TITLE
Added proper DISTINCT functionality.

### DIFF
--- a/lib/dialect/mssql.js
+++ b/lib/dialect/mssql.js
@@ -263,25 +263,10 @@ Mssql.prototype.visitOrderBy = function(orderBy) {
  * @returns {String[]}
  */
 Mssql.prototype.visitQueryHelper=function(actions,targets,filters){
-	/**
-	 *
-	 * @param {Node[]} list
-	 * @param {String} type
-	 * @returns {Object|undefined} {index:number, node:Node}
-	 * @private
-	 */
-	function _findNode(list,type){
-		for (var i= 0, len=list.length; i<len; i++) {
-			var n=list[i];
-			if (n.type==type) return {index:i,node:n};
-		}
-		return undefined
-	}
-
 	function _handleLimitAndOffset(){
-		var limitInfo=_findNode(filters,"LIMIT");
-		var offsetInfo=_findNode(filters,"OFFSET");
-		var orderByInfo=_findNode(filters,"ORDER BY");
+		var limitInfo=Mssql.super_.prototype.findNode.call(this, filters, "LIMIT");
+		var offsetInfo=Mssql.super_.prototype.findNode.call(this, filters, "OFFSET");
+		var orderByInfo=Mssql.super_.prototype.findNode.call(this, filters, "ORDER BY");
 
 		// no OFFSET or LIMIT then there's nothing special to do
 		if (!offsetInfo && !limitInfo) return;
@@ -298,7 +283,7 @@ Mssql.prototype.visitQueryHelper=function(actions,targets,filters){
 	 * @private
 	 */
 	function _processLimit(limitInfo){
-		var selectInfo=_findNode(actions,"SELECT");
+		var selectInfo=Mssql.super_.prototype.findNode.call(this, actions, "SELECT");
 		assert(selectInfo!=undefined,"MS SQL Server requires a SELECT clause when using LIMIT");
 		// save the LIMIT node with the SELECT node
 		selectInfo.node.msSQLLimitNode=limitInfo.node;
@@ -325,6 +310,7 @@ Mssql.prototype.visitQueryHelper=function(actions,targets,filters){
 
 	// MAIN
 
+  Mssql.super_.prototype.handleDistinct.call(this, actions, filters);
 	_handleLimitAndOffset();
 
 	// lazy-man sorting

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -108,6 +108,7 @@ Postgres.prototype.visit = function(node) {
     case 'CREATE'          : return this.visitCreate(node);
     case 'DROP'            : return this.visitDrop(node);
     case 'TRUNCATE'        : return this.visitTruncate(node);
+    case 'DISTINCT'        : return this.visitDistinct(node);
     case 'ALIAS'           : return this.visitAlias(node);
     case 'ALTER'           : return this.visitAlter(node);
     case 'CAST'            : return this.visitCast(node);
@@ -178,7 +179,9 @@ Postgres.prototype.quote = function(word, quoteCharacter) {
 };
 
 Postgres.prototype.visitSelect = function(select) {
-  var result = ['SELECT', select.nodes.map(this.visit.bind(this)).join(', ')];
+  var result = ['SELECT']
+  if (select.isDistinct) result.push('DISTINCT');
+  result.push(select.nodes.map(this.visit.bind(this)).join(', '));
   this._selectOrDeleteEndIndex = this.output.length + result.length;
   return result;
 };
@@ -285,6 +288,11 @@ Postgres.prototype.visitTruncate = function(truncate) {
   var result = ['TRUNCATE TABLE'];
   result = result.concat(truncate.nodes.map(this.visit.bind(this)));
   return result;
+};
+
+Postgres.prototype.visitDistinct = function(truncate) {
+  // Nothing to do here since it's handled in the SELECT clause
+  return [];
 };
 
 Postgres.prototype.visitAlias = function(alias) {
@@ -587,6 +595,7 @@ Postgres.prototype.visitQuery = function(queryNode) {
  * @returns {String[]}
  */
 Postgres.prototype.visitQueryHelper=function(actions,targets,filters){
+	this.handleDistinct(actions, filters)
 	// lazy-man sorting
 	var sortedNodes = actions.concat(targets).concat(filters);
 	for(var i = 0; i < sortedNodes.length; i++) {
@@ -903,5 +912,35 @@ Postgres.prototype.visitDropIndex = function(node) {
 
   return result;
 };
+
+/**
+ * Broken out as a separate function so that dialects that derive from this class can still use this functionality.
+ *
+ * @param {Node[]} list
+ * @param {String} type
+ * @returns {Object|undefined} {index:number, node:Node}
+ */
+Postgres.prototype.findNode=function(list,type) {
+	for (var i= 0, len=list.length; i<len; i++) {
+		var n=list[i];
+		if (n.type==type) return {index:i,node:n};
+	}
+	return undefined
+}
+
+/**
+ * pulls the DISTINCT node out of the filters and flags the SELECT node that it should be distinct.
+ * Broken out as a separate function so that dialects that derive from this class can still use this functionality.
+ */
+Postgres.prototype.handleDistinct = function(actions,filters) {
+	var distinctNode = this.findNode(filters,"DISTINCT");
+	//if (!distinctNode) distinctNode = _findNode(targets,"DISTINCT");
+	//if (!distinctNode) distinctNode = _findNode(actions,"DISTINCT");
+	if (!distinctNode) return
+	var selectInfo = this.findNode(actions,"SELECT");
+	if (!selectInfo) return // there should be one by now, I think
+	// mark the SELECT node that it's distinct
+	selectInfo.node.isDistinct = true;
+}
 
 module.exports = Postgres;

--- a/lib/node/distinct.js
+++ b/lib/node/distinct.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var Node = require(__dirname);
+
+module.exports = Node.define({
+  type: 'DISTINCT',
+});

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -21,6 +21,7 @@ var ForShare        = require('./forShare');
 var Create          = require('./create');
 var Drop            = require('./drop');
 var Truncate        = require('./truncate');
+var Distinct        = require('./distinct');
 var Alter           = require('./alter');
 var AddColumn       = require('./addColumn');
 var DropColumn      = require('./dropColumn');
@@ -310,6 +311,10 @@ var Query = Node.define({
 
   truncate: function() {
     return this.add(new Truncate(this.table));
+  },
+
+  distinct: function() {
+    return this.add(new Distinct());
   },
 
   alter: function() {

--- a/lib/node/select.js
+++ b/lib/node/select.js
@@ -10,6 +10,8 @@ module.exports = Node.define({
         this.sql = arg.sql;
     }
     // used when processing LIMIT clauses in MSSQL
-    this.msSQLLimitNode=undefined;
+    this.msSQLLimitNode = undefined;
+    // set to true when a DISTINCT is used on the entire result set
+    this.isDistinct = false;
   }
 });

--- a/test/dialects/distinct-tests.js
+++ b/test/dialects/distinct-tests.js
@@ -44,3 +44,69 @@ Harness.test({
   },
   params: []
 });
+
+// BELOW HERE TEST DISTINCT ON THE ENTIRE RESULTS SET, NOT JUST ONE COLUMN
+
+Harness.test({
+  query: user.select().distinct(),
+  pg: {
+    text  : 'SELECT DISTINCT "user".* FROM "user"',
+    string: 'SELECT DISTINCT "user".* FROM "user"'
+  },
+  sqlite: {
+    text  : 'SELECT DISTINCT "user".* FROM "user"',
+    string: 'SELECT DISTINCT "user".* FROM "user"'
+  },
+  mysql: {
+    text  : 'SELECT DISTINCT `user`.* FROM `user`',
+    string: 'SELECT DISTINCT `user`.* FROM `user`'
+  },
+  mssql: {
+    text  : 'SELECT DISTINCT [user].* FROM [user]',
+    string: 'SELECT DISTINCT [user].* FROM [user]'
+  },
+  params: []
+});
+
+Harness.test({
+  query: user.select(user.id).distinct(),
+  pg: {
+    text  : 'SELECT DISTINCT "user"."id" FROM "user"',
+    string: 'SELECT DISTINCT "user"."id" FROM "user"'
+  },
+  sqlite: {
+    text  : 'SELECT DISTINCT "user"."id" FROM "user"',
+    string: 'SELECT DISTINCT "user"."id" FROM "user"'
+  },
+  mysql: {
+    text  : 'SELECT DISTINCT `user`.`id` FROM `user`',
+    string: 'SELECT DISTINCT `user`.`id` FROM `user`'
+  },
+  mssql: {
+    text  : 'SELECT DISTINCT [user].[id] FROM [user]',
+    string: 'SELECT DISTINCT [user].[id] FROM [user]'
+  },
+  params: []
+});
+
+Harness.test({
+  query: user.select(user.id,user.name).distinct(),
+  pg: {
+    text  : 'SELECT DISTINCT "user"."id", "user"."name" FROM "user"',
+    string: 'SELECT DISTINCT "user"."id", "user"."name" FROM "user"'
+  },
+  sqlite: {
+    text  : 'SELECT DISTINCT "user"."id", "user"."name" FROM "user"',
+    string: 'SELECT DISTINCT "user"."id", "user"."name" FROM "user"'
+  },
+  mysql: {
+    text  : 'SELECT DISTINCT `user`.`id`, `user`.`name` FROM `user`',
+    string: 'SELECT DISTINCT `user`.`id`, `user`.`name` FROM `user`'
+  },
+  mssql: {
+    text  : 'SELECT DISTINCT [user].[id], [user].[name] FROM [user]',
+    string: 'SELECT DISTINCT [user].[id], [user].[name] FROM [user]'
+  },
+  params: []
+});
+

--- a/test/dialects/insert-tests.js
+++ b/test/dialects/insert-tests.js
@@ -408,6 +408,27 @@ Harness.test({
   params: ['A%']
 });
 
+Harness.test({
+  query: post.insert(post.userId).select(user.id).distinct().from(user),
+  pg: {
+    text  : 'INSERT INTO "post" ("userId") SELECT DISTINCT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT DISTINCT "user"."id" FROM "user"'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "post" ("userId") SELECT DISTINCT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT DISTINCT "user"."id" FROM "user"'
+  },
+  mysql: {
+    text  : 'INSERT INTO `post` (`userId`) SELECT DISTINCT `user`.`id` FROM `user`',
+    string: 'INSERT INTO `post` (`userId`) SELECT DISTINCT `user`.`id` FROM `user`'
+  },
+  mssql: {
+    text  : 'INSERT INTO [post] ([userId]) SELECT DISTINCT [user].[id] FROM [user]',
+    string: 'INSERT INTO [post] ([userId]) SELECT DISTINCT [user].[id] FROM [user]'
+  },
+  params: []
+});
+
 // Binary inserts
 Harness.test({
   query: post.insert(post.content.value(new Buffer('test')), post.userId.value(2)),


### PR DESCRIPTION
This resolves the DISTINCT issue described in #226 where DISTINCT currently only works on one column. With this change it is possible to
```
var query=posts.select(post.id,post.user).distinct()
```
which will generate (properly quoted)
```
SELECT DISTINCT post.id, post.user FROM post
```
I believe this generates correct SQL for all four currently supported dialects.

I did not make any changes to the current way distinct works on columns.

I also re-factored some common code out of the mssql module so that it can be better shared.