### PR TITLE
Implemented Rename Columns for MSSQL

### DIFF
--- a/lib/dialect/mssql.js
+++ b/lib/dialect/mssql.js
@@ -99,19 +99,17 @@ Mssql.prototype.visitAlter = function(alter) {
 
   // Implement our own rename column:
   //   PostgreSQL: ALTER TABLE "group" RENAME COLUMN "userId" TO "newUserId"
-  //   Mssql:  EXEC sp_rename [group], [userId], [newUserId]
+  //   Mssql:  EXEC sp_rename '[group].[userId]', [newUserId]
   function _renameColumn(){
-    // TODO: implement this. Need to be able to get the [tableName.Column], which is hard to do with the current way visitXxx works
-    throw new Error('Mssql renaming columns not yet implemented');
-//    self._visitingAlter = true;
-//    var table = self._queryNode.table;
-//    var result = ['EXEC sp_rename '+
-//      self.visit(table.toNode())+'.'+self.visit(alter.nodes[0].nodes[0])+', '+
-//      self.visit(alter.nodes[0].nodes[1])+', '+
-//      "'COLUMN'"
-//      ];
-//    self._visitingAlter = false;
-//    return result
+   self._visitingAlter = true;
+   var table = self._queryNode.table;
+   var result = ["EXEC sp_rename '"+
+     self.visit(table.toNode())+'.'+self.visit(alter.nodes[0].nodes[0])+"', "+
+     self.visit(alter.nodes[0].nodes[1])+', '+
+     "'COLUMN'"
+     ];
+   self._visitingAlter = false;
+   return result
   }
 
   if (isAlterAddColumn(alter)) return _addColumn();

--- a/test/dialects/alter-table-tests.js
+++ b/test/dialects/alter-table-tests.js
@@ -178,10 +178,8 @@ Harness.test({
     throws: true
   },
   mssql: {
-    text  : 'Mssql renaming columns not yet implemented',
-    throws: true
-//    text  : 'EXEC sp_rename [group.userId], [newUserId], \'COLUMN\'',
-//    string: 'EXEC sp_rename [group.userId], [newUserId], \'COLUMN\''
+   text  : 'EXEC sp_rename \'[group].[userId]\', [newUserId], \'COLUMN\'',
+   string: 'EXEC sp_rename \'[group].[userId]\', [newUserId], \'COLUMN\''
   },
   params: []
 });
@@ -201,10 +199,8 @@ Harness.test({
     string: 'ALTER TABLE `group` CHANGE COLUMN `userId` `newUserId` varchar(100)'
   },
   mssql: {
-    text  : 'Mssql renaming columns not yet implemented',
-    throws: true
-//    text  : 'EXEC sp_rename [group.userId], [newUserId], \'COLUMN\'',
-//    string: 'EXEC sp_rename [group.userId], [newUserId], \'COLUMN\''
+   text  : 'EXEC sp_rename \'[group].[userId]\', [newUserId], \'COLUMN\'',
+   string: 'EXEC sp_rename \'[group].[userId]\', [newUserId], \'COLUMN\''
   },
   params: []
 });
@@ -224,10 +220,8 @@ Harness.test({
     string: 'ALTER TABLE `group` CHANGE COLUMN `userId` `id` varchar(100)'
   },
   mssql: {
-    text  : 'Mssql renaming columns not yet implemented',
-    throws: true
-//    text  : 'EXEC sp_rename [group.userId], [id], \'COLUMN\'',
-//    string: 'EXEC sp_rename [group.userId], [id], \'COLUMN\''
+   text  : 'EXEC sp_rename \'[group].[userId]\', [id], \'COLUMN\'',
+   string: 'EXEC sp_rename \'[group].[userId]\', [id], \'COLUMN\''
   },
   params: []
 });
@@ -256,10 +250,8 @@ Harness.test({
     throws: true
   },
   mssql: {
-    text  : 'Mssql renaming columns not yet implemented',
-    throws: true
-//    text  : 'EXEC sp_rename [UserWithSignature.Signature], [sig], \'COLUMN\'',
-//    string: 'EXEC sp_rename [UserWithSignature.Signature], [sig], \'COLUMN\''
+   text  : 'EXEC sp_rename \'[UserWithSignature].[Signature]\', [sig], \'COLUMN\'',
+   string: 'EXEC sp_rename \'[UserWithSignature].[Signature]\', [sig], \'COLUMN\''
   }
 });
 


### PR DESCRIPTION
I changed the commented code, adding apostrophes to the original column name, since this is also supported for MSSQL. 
This way, the generated rename statement will be something like this:
- exec sp_rename '[group].[userId]', [newUserId], 'column'

Also changed the tests to reflect this change.