### PR TITLE
MSSQL LENGTH function fix

### DIFF
--- a/lib/dialect/mssql.js
+++ b/lib/dialect/mssql.js
@@ -234,6 +234,14 @@ Mssql.prototype.visitDrop = function(drop) {
   return ['IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES '+whereClause+') BEGIN '+dropResult.join(' ')+' END'];
 };
 
+Mssql.prototype.visitFunctionCall = function(functionCall) {
+	var name=functionCall.name
+	// override the LENGTH function since mssql calls it LEN
+	if (name=="LENGTH") name="LEN"
+  var txt = name + '(' + functionCall.nodes.map(this.visit.bind(this)).join(', ') + ')';
+  return [txt];
+};
+
 Mssql.prototype.visitOrderBy = function(orderBy) {
 	var result=Mssql.super_.prototype.visitOrderBy.call(this, orderBy);
 	var offsetNode=orderBy.msSQLOffsetNode;

--- a/test/dialects/function-tests.js
+++ b/test/dialects/function-tests.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var Harness = require('./support');
+var Sql = require('../../lib');
+
+var post = Harness.definePostTable();
+
+Harness.test({
+  query: post.select(Sql.functions.LENGTH(post.content)),
+  pg: {
+    text  : 'SELECT LENGTH("post"."content") FROM "post"',
+    string: 'SELECT LENGTH("post"."content") FROM "post"'
+  },
+  sqlite: {
+    text  : 'SELECT LENGTH("post"."content") FROM "post"',
+    string: 'SELECT LENGTH("post"."content") FROM "post"'
+  },
+  mysql: {
+    text  : 'SELECT LENGTH(`post`.`content`) FROM `post`',
+    string: 'SELECT LENGTH(`post`.`content`) FROM `post`'
+  },
+  mssql: {
+    text  : 'SELECT LEN([post].[content]) FROM [post]',
+    string: 'SELECT LEN([post].[content]) FROM [post]'
+  },
+  oracle: {
+    text  : 'SELECT LENGTH("post"."content") FROM "post"',
+    string: 'SELECT LENGTH("post"."content") FROM "post"'
+  },
+  params: []
+});
+


### PR DESCRIPTION
Microsoft SQL Server uses LEN instead of LENGTH. This pull request fixes it.

I've added a function-tests.js file to the test/dialects directory to validate that the existing code still works. This file could be expanded to include tests for all the common functions across all dialects.