### PR TITLE
Adds Create View Support - closes #245

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -71,10 +71,20 @@ Postgres.prototype.getQuery = function(queryNode) {
     queryNode = queryNode.select(queryNode.star());
   }
   this.output = this.visit(queryNode);
-
+  
+  //if is a create view, must replace paramaters with values
+  if (this.output.indexOf('CREATE VIEW') > -1) {
+    var previousFlagStatus = this._disableParameterPlaceholders;
+    this._disableParameterPlaceholders = true;
+    this.output = [];
+    this.output = this.visit(queryNode);
+    this.params = [];
+    this._disableParameterPlaceholders = previousFlagStatus;
+  }
+  
   // create the query object
   var query = { text: this.output.join(' '), values: this.params };
-
+   
   // reset the internal state of this builder
   this.output = [];
   this.params = [];
@@ -142,7 +152,8 @@ Postgres.prototype.visit = function(node) {
     case 'DROP INDEX'      : return this.visitDropIndex(node);
     case 'FUNCTION CALL'   : return this.visitFunctionCall(node);
     case 'ARRAY CALL'      : return this.visitArrayCall(node);
-
+    case 'CREATE VIEW'     : return this.visitCreateView(node);
+    
     case 'POSTFIX UNARY' : return this.visitPostfixUnary(node);
     case 'PREFIX UNARY'  : return this.visitPrefixUnary(node);
     case 'BINARY'        : return this.visitBinary(node);
@@ -547,6 +558,8 @@ Postgres.prototype.visitQuery = function(queryNode) {
   // so select/insert/update/delete comes before from comes before where
   var missingFrom = true;
   var hasFrom     = false;
+  var createView;
+  var isSelect     = false;
   var actions = [];
   var targets = [];
   var filters = [];
@@ -554,6 +567,7 @@ Postgres.prototype.visitQuery = function(queryNode) {
     var node = queryNode.nodes[i];
     switch(node.type) {
       case "SELECT":
+        isSelect = true;
       case "DELETE":
         actions.push(node);
         break;
@@ -573,6 +587,9 @@ Postgres.prototype.visitQuery = function(queryNode) {
         missingFrom = false;
         targets.push(node);
         break;
+      case "CREATE VIEW":
+        createView = node;
+        break;
       default:
         filters.push(node);
         break;
@@ -581,9 +598,17 @@ Postgres.prototype.visitQuery = function(queryNode) {
   if(!actions.length) {
     // if no actions are given, guess it's a select
     actions.push(new Select().add('*'));
+    isSelect = true;
   }
   if(missingFrom) {
     targets.push(new From().add(queryNode.table));
+  }
+  if (createView) {
+    if (isSelect) {
+      actions.unshift(createView);
+    } else {
+      throw new Error('Create View requires a Select.');
+    }
   }
   return this.visitQueryHelper(actions,targets,filters)
 };
@@ -923,6 +948,12 @@ Postgres.prototype.visitDropIndex = function(node) {
 
   result.push(this.quote(node.table.getSchema() || "public") + "." + this.quote(node.options.indexName));
 
+  return result;
+};
+
+Postgres.prototype.visitCreateView = function(createView) {
+  //console.log('createView: ' + createView);
+  var result = ['CREATE VIEW', this.quote(createView.options.viewName), 'AS'];
   return result;
 };
 

--- a/lib/node/createView.js
+++ b/lib/node/createView.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var Node = require(__dirname);
+
+module.exports = Node.define({
+  type: 'CREATE VIEW',
+
+  constructor: function(viewName) {
+    Node.call(this);
+
+    this.options = { viewName: viewName};
+  }
+});

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -38,6 +38,7 @@ var Indexes         = require('./indexes');
 var CreateIndex     = require('./createIndex');
 var DropIndex       = require('./dropIndex');
 var Table           = require('./table');
+var CreateView     = require('./createView');
 
 var Modifier = Node.define({
   constructor: function(table, type, count) {
@@ -432,6 +433,11 @@ var Query = Node.define({
       table: this.table
     });
     return this.add(this.indexesClause);
+  },
+  
+  createView: function(viewName) {
+    this.add(new CreateView(viewName));
+    return this;
   }
 });
 

--- a/test/dialects/create-view-tests.js
+++ b/test/dialects/create-view-tests.js
@@ -52,3 +52,29 @@ Harness.test({
     string: 'CREATE VIEW "oneUserView" AS SELECT "user".* FROM "user" WHERE ("user"."id" = 1)'
   }
 });
+
+//Tests error raised for non-SELECT create view attempts
+Harness.test({
+  query: user.delete().where(user.id.equals(1)).createView('oneUserView'),
+  pg: {
+    text  : 'Create View requires a Select.',
+    throws: true
+  },
+  sqlite: {
+    text  : 'Create View requires a Select.',
+    throws: true
+  },
+  mysql: {
+    text  : 'Create View requires a Select.',
+    throws: true
+  },
+  mssql: {
+    text  : 'Create View requires a Select.',
+    throws: true
+  },
+  oracle: {
+    text  : 'Create View requires a Select.',
+    throws: true
+  },
+  params: []
+});

--- a/test/dialects/create-view-tests.js
+++ b/test/dialects/create-view-tests.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var Harness = require('./support');
+var user = Harness.defineUserTable();
+
+//simple view create
+Harness.test({
+  query: user.select(user.star()).createView('allUsersView'),
+  pg: {
+    text  : 'CREATE VIEW "allUsersView" AS SELECT "user".* FROM "user"',
+    string: 'CREATE VIEW "allUsersView" AS SELECT "user".* FROM "user"'
+  },
+  sqlite: {
+    text  : 'CREATE VIEW "allUsersView" AS SELECT "user".* FROM "user"',
+    string: 'CREATE VIEW "allUsersView" AS SELECT "user".* FROM "user"'
+  },
+  mysql: {
+    text  : 'CREATE VIEW `allUsersView` AS SELECT `user`.* FROM `user`',
+    string: 'CREATE VIEW `allUsersView` AS SELECT `user`.* FROM `user`'
+  },
+  mssql: {
+    text  : 'CREATE VIEW [allUsersView] AS SELECT [user].* FROM [user]',
+    string: 'CREATE VIEW [allUsersView] AS SELECT [user].* FROM [user]'
+  },
+  oracle: {
+    text  : 'CREATE VIEW "allUsersView" AS SELECT "user".* FROM "user"',
+    string: 'CREATE VIEW "allUsersView" AS SELECT "user".* FROM "user"'
+  }
+});
+
+//create view with parameters
+Harness.test({
+  query: user.select(user.star()).where(user.id.equals(1)).createView('oneUserView'),
+  pg: {
+    text  : 'CREATE VIEW "oneUserView" AS SELECT "user".* FROM "user" WHERE ("user"."id" = 1)',
+    string: 'CREATE VIEW "oneUserView" AS SELECT "user".* FROM "user" WHERE ("user"."id" = 1)'
+  },
+  sqlite: {
+    text  : 'CREATE VIEW "oneUserView" AS SELECT "user".* FROM "user" WHERE ("user"."id" = 1)',
+    string: 'CREATE VIEW "oneUserView" AS SELECT "user".* FROM "user" WHERE ("user"."id" = 1)'
+  },
+  mysql: {
+    text  : 'CREATE VIEW `oneUserView` AS SELECT `user`.* FROM `user` WHERE (`user`.`id` = 1)',
+    string: 'CREATE VIEW `oneUserView` AS SELECT `user`.* FROM `user` WHERE (`user`.`id` = 1)'
+  },
+  mssql: {
+    text  : 'CREATE VIEW [oneUserView] AS SELECT [user].* FROM [user] WHERE ([user].[id] = 1)',
+    string: 'CREATE VIEW [oneUserView] AS SELECT [user].* FROM [user] WHERE ([user].[id] = 1)'
+  },
+  oracle: {
+    text  : 'CREATE VIEW "oneUserView" AS SELECT "user".* FROM "user" WHERE ("user"."id" = 1)',
+    string: 'CREATE VIEW "oneUserView" AS SELECT "user".* FROM "user" WHERE ("user"."id" = 1)'
+  }
+});


### PR DESCRIPTION
Hi.

As proposed in #245, I implemented a Create View support. The idea is that any select query can be turned into a view by calling the ```createView``` method.

So, an example of use would be:

```javascript
var sql = require('sql');

var user = sql.define({
  name: 'user',
  columns: ['id', 'name']
});

var query = user.select(user.star()).where(user.id.equals(1));

var view = query.createView('myView');

var text = view.toQuery();
```

This returns a query object as folows. Note that since we are creating a view, the parameters are replaced with its values.
```javascript
   {
      text: 'CREATE VIEW "myView" AS SELECT "user".* FROM "user" WHERE ("user"."id" = 1)',
      values: [] 
   }
```

Any doubts, just get in touch...