### PR TITLE
Added LEFT and RIGHT functions.

### DIFF
--- a/lib/dialect/sqlite.js
+++ b/lib/dialect/sqlite.js
@@ -34,6 +34,34 @@ Sqlite.prototype.visitDropColumn = function() {
   throw new Error('SQLite does not allow dropping columns.');
 };
 
+Sqlite.prototype.visitFunctionCall = function(functionCall) {
+	var _this=this
+
+	function _left() {
+		// convert LEFT(column,4) to SUBSTR(column,1,4)
+		var nodes = functionCall.nodes.map(_this.visit.bind(_this))
+		if (nodes.length != 2) throw new Error('Not enough parameters passed to LEFT function.')
+		var txt = "SUBSTR(" + (nodes[0]+'') + ', 1, ' + (nodes[1]+'') + ')';
+		return txt
+	}
+
+	function _right() {
+		// convert RIGHT(column,4) to SUBSTR(column,-4)
+		var nodes = functionCall.nodes.map(_this.visit.bind(_this))
+		if (nodes.length != 2) throw new Error('Not enough parameters passed to RIGHT function.')
+		var txt = "SUBSTR(" + (nodes[0]+'') + ', -' + (nodes[1]+'') + ')';
+		return txt
+	}
+
+	var txt=""
+	var name=functionCall.name
+	// Override LEFT and RIGHT and convert to SUBSTR
+	if (name == "LEFT") txt = _left();
+	else if (name == "RIGHT") txt = _right();
+	else txt = name + '(' + functionCall.nodes.map(this.visit.bind(this)).join(', ') + ')';
+  return [txt];
+};
+
 Sqlite.prototype.visitTruncate = function(truncate) {
   var result = ['DELETE FROM'];
   result = result.concat(truncate.nodes.map(this.visit.bind(this)));

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -36,10 +36,12 @@ var aggregateFunctions = [
 var scalarFunctions = [
   'ABS',
   'COALESCE',
+  'LEFT',
   'LENGTH',
   'LOWER',
   'LTRIM',
   'RANDOM',
+  'RIGHT',
   'ROUND',
   'RTRIM',
   'SUBSTR',

--- a/test/dialects/function-tests.js
+++ b/test/dialects/function-tests.js
@@ -30,3 +30,53 @@ Harness.test({
   params: []
 });
 
+Harness.test({
+  query: post.select(Sql.functions.LEFT(post.content,4)),
+  pg: {
+    text  : 'SELECT LEFT("post"."content", $1) FROM "post"',
+    string: 'SELECT LEFT("post"."content", 4) FROM "post"'
+  },
+  sqlite: {
+    text  : 'SELECT SUBSTR("post"."content", 1, $1) FROM "post"',
+    string: 'SELECT SUBSTR("post"."content", 1, 4) FROM "post"'
+  },
+  mysql: {
+    text  : 'SELECT LEFT(`post`.`content`, ?) FROM `post`',
+    string: 'SELECT LEFT(`post`.`content`, 4) FROM `post`'
+  },
+  mssql: {
+    text  : 'SELECT LEFT([post].[content], @1) FROM [post]',
+    string: 'SELECT LEFT([post].[content], 4) FROM [post]'
+  },
+  oracle: {
+    text  : 'SELECT LEFT("post"."content", :1) FROM "post"',
+    string: 'SELECT LEFT("post"."content", 4) FROM "post"'
+  },
+  params: [4]
+});
+
+Harness.test({
+  query: post.select(Sql.functions.RIGHT(post.content,4)),
+  pg: {
+    text  : 'SELECT RIGHT("post"."content", $1) FROM "post"',
+    string: 'SELECT RIGHT("post"."content", 4) FROM "post"'
+  },
+  sqlite: {
+    text  : 'SELECT SUBSTR("post"."content", -$1) FROM "post"',
+    string: 'SELECT SUBSTR("post"."content", -4) FROM "post"'
+  },
+  mysql: {
+    text  : 'SELECT RIGHT(`post`.`content`, ?) FROM `post`',
+    string: 'SELECT RIGHT(`post`.`content`, 4) FROM `post`'
+  },
+  mssql: {
+    text  : 'SELECT RIGHT([post].[content], @1) FROM [post]',
+    string: 'SELECT RIGHT([post].[content], 4) FROM [post]'
+  },
+  oracle: {
+    text  : 'SELECT RIGHT("post"."content", :1) FROM "post"',
+    string: 'SELECT RIGHT("post"."content", 4) FROM "post"'
+  },
+  params: [4]
+});
+


### PR DESCRIPTION
This adds the LEFT and RIGHT string functions. These are standard functions in PostgreSQL, MySQL, Microsoft SQL Server and Oracle. These functions don't exist in SQLite so this pull request converts them into a call to SUBSTR. For example,

```javascript
var sql=require("sql")
var leftQuery=post.select(sql.functions.LEFT(post.content,4))
var rightQuery=post.select(sql.functions.RIGHT(post.content,4))
```
in all dialects except SQLite will generate
```sql
SELECT LEFT("post"."content",4) FROM "post"
SELECT RIGHT("post"."content",4) FROM "post"
```
but in SQLite will generate
```sql
SELECT SUBSTR("post"."content",1,4) FROM "post"
SELECT SUBSTR("post"."content",-4) FROM "post"
```
