### PR TITLE
Function calls don't need the sql instance.

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -4,19 +4,17 @@ var sliced = require('sliced');
 var FunctionCall = require(__dirname + '/node/functionCall');
 
 // create a function that creates a function call of the specific name, using the specified sql instance
-var getFunctionCallCreator = function(name, sql) {
+var getFunctionCallCreator = function(name) {
   return function() {
     // turn array-like arguments object into a true array
-    var functionCall = new FunctionCall(name, sliced(arguments));
-    functionCall.sql = sql;
-    return functionCall;
+    return new FunctionCall(name, sliced(arguments));
   };
 };
 
 // creates a hash of functions for a sql instance
-var getFunctions = function(functionNames, sql) {
+var getFunctions = function(functionNames) {
   var functions = _.reduce(functionNames, function(reducer, name) {
-    reducer[name] = getFunctionCallCreator(name, sql);
+    reducer[name] = getFunctionCallCreator(name);
     return reducer;
   }, {});
   return functions;
@@ -56,8 +54,8 @@ var textsearchFunctions = ['TS_RANK','TS_RANK_CD', 'PLAINTO_TSQUERY', 'TO_TSQUER
 var standardFunctionNames = aggregateFunctions.concat(scalarFunctions).concat(hstoreFunction).concat(textsearchFunctions);
 
 // creates a hash of standard functions for a sql instance
-var getStandardFunctions = function(sql) {
-  return getFunctions(standardFunctionNames, sql);
+var getStandardFunctions = function() {
+  return getFunctions(standardFunctionNames);
 };
 
 module.exports.getStandardFunctions = getStandardFunctions;

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var Sql = function(dialect) {
   this.setDialect(dialect || DEFAULT_DIALECT);
 
   // attach the standard SQL functions to this instance
-  this.functions = functions.getStandardFunctions(this);
+  this.functions = functions.getStandardFunctions();
 };
 
 // Define a table
@@ -30,11 +30,8 @@ Sql.prototype.define = function(def) {
 
 // Returns a function call creator
 Sql.prototype.functionCallCreator = function(name) {
-  var sql = this;
   return function() {
-    var functionCall = new FunctionCall(name, sliced(arguments));
-    functionCall.sql = sql;
-    return functionCall;
+    return new FunctionCall(name, sliced(arguments));
   };
 };
 


### PR DESCRIPTION
From what I can tell, the sql instance is never accessed from a function call. Seems like we can just drop it!