### PR TITLE
Added configurability for dialects

### DIFF
--- a/lib/dialect/sqlite.js
+++ b/lib/dialect/sqlite.js
@@ -3,10 +3,11 @@
 var util = require('util');
 var assert = require('assert');
 
-var Sqlite = function() {
+var Sqlite = function(config) {
   this.output = [];
   this.params = [];
   this._hasAddedAColumn = false;
+  this.config = config || {};
 };
 
 var Postgres = require(__dirname + '/postgres');
@@ -20,6 +21,8 @@ Sqlite.prototype._arrayAggFunctionName = 'GROUP_CONCAT';
 Sqlite.prototype._getParameterValue = function(value) {
   if (Buffer.isBuffer(value)) {
     value = 'x' + this._getParameterValue(value.toString('hex'));
+  } else if (value instanceof Date && this.config.dateTimeMillis) {
+    value = value.getTime();
   } else {
     value = Postgres.prototype._getParameterValue.call(this, value);
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,8 +12,8 @@ var Table        = require('./table');
 // default dialect is postgres
 var DEFAULT_DIALECT = 'postgres';
 
-var Sql = function(dialect) {
-  this.setDialect(dialect || DEFAULT_DIALECT);
+var Sql = function(dialect, config) {
+  this.setDialect(dialect || DEFAULT_DIALECT, config);
 
   // attach the standard SQL functions to this instance
   this.functions = functions.getStandardFunctions();
@@ -50,19 +50,20 @@ Sql.prototype.select = function() {
 };
 
 // Set the dialect
-Sql.prototype.setDialect = function(dialect) {
+Sql.prototype.setDialect = function(dialect, config) {
   this.dialect     = getDialect(dialect);
   this.dialectName = dialect;
+  this.config      = config;
 
   return this;
 };
 
 // back compat shim for the Sql class constructor
-var create = function(dialect) {
-  return new Sql(dialect);
+var create = function(dialect, config) {
+  return new Sql(dialect, {});
 };
 
-module.exports = new Sql(DEFAULT_DIALECT);
+module.exports = new Sql(DEFAULT_DIALECT, {});
 module.exports.create = create;
 module.exports.Sql = Sql;
 module.exports.Table = Table;

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -45,9 +45,14 @@ var determineDialect = function(query, dialect) {
   return Dialect;
 };
 
+var initializeDialect = function(Dialect, query) {
+    var config = query.sql ? query.sql.config : {};
+    return new Dialect(config);
+};
+
 Node.prototype.toQuery = function(dialect) {
   var Dialect = determineDialect(this, dialect);
-  return new Dialect().getQuery(this);
+  return initializeDialect(Dialect, this).getQuery(this);
 };
 
 Node.prototype.toNamedQuery = function(name, dialect) {
@@ -61,7 +66,7 @@ Node.prototype.toNamedQuery = function(name, dialect) {
 
 Node.prototype.toString = function(dialect) {
   var Dialect = determineDialect(this, dialect);
-  return new Dialect().getString(this);
+  return initializeDialect(Dialect, this).getString(this);
 };
 
 Node.prototype.addAll = function(nodes) {

--- a/test/dialects/support.js
+++ b/test/dialects/support.js
@@ -27,11 +27,11 @@ module.exports = {
           // check if this query is expected to throw
           if (expectedObject.throws) {
             assert.throws(function() {
-              new DialectClass().getQuery(expected.query);
+              new DialectClass(expectedObject.config).getQuery(expected.query);
             });
           } else {
             // build query for dialect
-            var compiledQuery = new DialectClass().getQuery(expected.query);
+            var compiledQuery = new DialectClass(expectedObject.config).getQuery(expected.query);
 
             // test result is correct
             var expectedText = expectedObject.text || expectedObject;
@@ -51,10 +51,10 @@ module.exports = {
             // test the toString
             if (expectedObject.throws) {
               assert.throws(function() {
-                new DialectClass().getString(expected.query);
+                new DialectClass(expectedObject.config).getString(expected.query);
               });
             } else {
-              var compiledString = new DialectClass().getString(expected.query);
+              var compiledString = new DialectClass(expectedObject.config).getString(expected.query);
 
               // test result is correct
               assert.equal(compiledString, expectedObject.string);

--- a/test/dialects/tostring-tests.js
+++ b/test/dialects/tostring-tests.js
@@ -134,6 +134,35 @@ Harness.test({
   params: [new Date('Sat, 01 Jan 2000 00:00:00 GMT')]
 });
 
+// Date to milliseconds
+Harness.test({
+  query: post.content.equals(new Date('Sat, 01 Jan 2000 00:00:00 GMT')),
+  pg: {
+    text  : '("post"."content" = $1)',
+    string: '("post"."content" = \'2000-01-01T00:00:00.000Z\')'
+  },
+  sqlite: {
+    text  : '("post"."content" = $1)',
+    string: '("post"."content" = 946684800000)',
+    config: {
+      dateTimeMillis: true
+    }
+  },
+  mysql: {
+    text  : '(`post`.`content` = ?)',
+    string: '(`post`.`content` = \'2000-01-01T00:00:00.000Z\')'
+  },
+  mssql: {
+    text  : '([post].[content] = @1)',
+    string: '([post].[content] = \'2000-01-01T00:00:00.000Z\')'
+  },
+  oracle: {
+    text  : '("post"."content" = :1)',
+    string: '("post"."content" = \'2000-01-01T00:00:00.000Z\')'
+  },
+  params: [new Date('Sat, 01 Jan 2000 00:00:00 GMT')]
+});
+
 // Object
 var customObject = {
   toString: function() {


### PR DESCRIPTION
We ran into a problem where we were inserting data into SQLite as a timestamp in development, and as a timestamp with time zone. When attempting to query for that data, the current default in the sqlite dialect is to call .toISOString() on the date object, which will only work if the user has stored all of their data in SQLite as ISO strings (since it will just do a lexicographic comparison).

With this update, Date objects are detected and the epoch milliseconds are used for comparisons if the user provides a configuration object denoting that they would like to perform this conversion. This introduces the concept of a configuration object for the dialects...which is a departure from how they were being used before. If anyone has suggestions on how to handle this differently, please let me know. 