### PR TITLE
returning() defaults to '*'

### DIFF
--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -257,9 +257,12 @@ var Query = Node.define({
   },
 
   returning: function() {
-    var args = getArrayOrArgsAsArray(arguments);
     var returning = new Returning();
-    returning.addAll(args);
+    if (arguments.length === 0)
+      returning.add('*');
+    else
+      returning.addAll(getArrayOrArgsAsArray(arguments));
+
     return this.add(returning);
   },
 
@@ -462,7 +465,7 @@ var Query = Node.define({
     });
     return this.add(this.indexesClause);
   },
-  
+
   createView: function(viewName) {
     this.add(new CreateView(viewName));
     return this;

--- a/test/dialects/returning-tests.js
+++ b/test/dialects/returning-tests.js
@@ -1,0 +1,20 @@
+var Harness = require('./support');
+var user = Harness.defineUserTable();
+
+Harness.test({
+  query: user.insert({name: 'joe'}).returning(),
+  pg: {
+    text  : 'INSERT INTO "user" ("name") VALUES ($1) RETURNING *',
+    string: 'INSERT INTO "user" ("name") VALUES (\'joe\') RETURNING *'
+  },
+  params: ['joe']
+});
+
+Harness.test({
+  query: user.insert({name: 'joe'}).returning('id'),
+  pg: {
+    text  : 'INSERT INTO "user" ("name") VALUES ($1) RETURNING id',
+    string: 'INSERT INTO "user" ("name") VALUES (\'joe\') RETURNING id'
+  },
+  params: ['joe']
+});


### PR DESCRIPTION
See #272

I wasn't able to find any tests for `returning` in particular, so I added second one to make sure nothing breaks (passing in an expression like `user.id.as('user_id')` also worked as expected, but that felt like too much to include).

Editor cleaned up some trailing whitespace by accident. "Oops"…