### PR TITLE
Added configuration for postgres dialect so that null order can be expressed

### DIFF
--- a/lib/dialect/mssql.js
+++ b/lib/dialect/mssql.js
@@ -6,9 +6,10 @@
 var util = require('util');
 var assert = require('assert');
 
-var Mssql = function() {
+var Mssql = function(config) {
   this.output = [];
   this.params = [];
+  this.config = config || {};
 };
 
 var Postgres = require(__dirname + '/postgres');

--- a/lib/dialect/mysql.js
+++ b/lib/dialect/mysql.js
@@ -3,9 +3,10 @@
 var util = require('util');
 var assert = require('assert');
 
-var Mysql = function() {
+var Mysql = function(config) {
   this.output = [];
   this.params = [];
+  this.config = config || {};
 };
 
 var Postgres = require(__dirname + '/postgres');

--- a/lib/dialect/oracle.js
+++ b/lib/dialect/oracle.js
@@ -3,9 +3,10 @@
 var util = require('util');
 var assert = require('assert');
 
-var Oracle = function() {
+var Oracle = function(config) {
   this.output = [];
   this.params = [];
+  this.config = config || {};
 };
 
 var Postgres = require(__dirname + '/postgres');
@@ -55,7 +56,7 @@ Oracle.prototype.visitDrop = function(drop) {
   }
   // Implement our own drop if exists:
   //   PostgreSQL: DROP TABLE IF EXISTS "group"
-  //   Oracle:  
+  //   Oracle:
   //     BEGIN
   //          EXECUTE IMMEDIATE 'DROP TABLE POST';
   //     EXCEPTION
@@ -80,7 +81,7 @@ Oracle.prototype.visitCreate = function(create) {
   if (isNotExists) {
       // Implement our own create if not exists:
       //   PostgreSQL: CREATE TABLE IF NOT EXISTS "group" ("id" varchar(100))
-      //   Oracle:  
+      //   Oracle:
       //     BEGIN
       //          EXECUTE IMMEDIATE 'CREATE TABLE ...';
       //     EXCEPTION
@@ -128,7 +129,7 @@ Oracle.prototype.visitModifier = function(node) {
 
 Oracle.prototype.visitQueryHelper=function(actions,targets,filters){
   var output = Oracle.super_.prototype.visitQueryHelper.call(this,actions,targets,filters);
-  
+
   //In Oracle, OFFSET must come before FETCH NEXT (limit)
   //Change positions, if both are present and not done already
   var offset = output.indexOf('OFFSET');
@@ -154,7 +155,7 @@ Oracle.prototype.visitColumn = function(columnNode) {
   function _arrayAgg(){
     throw new Error("Oracle does not support array_agg.")
   }
-  
+
   function _countStar(){
     // Implement our own since count(table.*) is invalid in Oracle
     var result='COUNT(*)'
@@ -196,11 +197,11 @@ Oracle.prototype.visitIndexes = function(node) {
   var schemaName = this._queryNode.table.getSchema();
 
   var indexes = "SELECT * FROM USER_INDEXES WHERE TABLE_NAME = '" + tableName + "'";
-  
+
   if (schemaName) {
     indexes += " AND TABLE_OWNER = '" + schemaName + "'";
   }
-  
+
   return indexes;
 };
 
@@ -219,9 +220,9 @@ Oracle.prototype.visitDropIndex = function(node) {
 
 // Using same CASE implementation as MSSQL
 Oracle.prototype.visitCase = function(caseExp) {
-  
+
   return Mssql.prototype.visitCase.call(this, caseExp);
-} 
+}
 
 
 function isCreateIfNotExists(create){

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -372,8 +372,8 @@ Postgres.prototype.visitWhere = function(where) {
 
 Postgres.prototype.visitOrderBy = function(orderBy) {
   var result = ['ORDER BY', orderBy.nodes.map(this.visit.bind(this)).join(', ')];
-  if (this._myClass === Postgres && this.config.nullsLast) {
-      result.push('NULLS LAST');
+  if (this._myClass === Postgres && this.config.nullOrder) {
+      result.push('NULLS ' + this.config.nullOrder.toUpperCase());
   }
   return result;
 };

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -6,9 +6,10 @@ var From   = require('../node/from');
 var Select = require('../node/select');
 var Table  = require('../table');
 
-var Postgres = function() {
+var Postgres = function(config) {
   this.output = [];
   this.params = [];
+  this.config = config || {};
 };
 
 Postgres.prototype._myClass = Postgres;
@@ -71,7 +72,7 @@ Postgres.prototype.getQuery = function(queryNode) {
     queryNode = queryNode.select(queryNode.star());
   }
   this.output = this.visit(queryNode);
-  
+
   //if is a create view, must replace paramaters with values
   if (this.output.indexOf('CREATE VIEW') > -1) {
     var previousFlagStatus = this._disableParameterPlaceholders;
@@ -81,10 +82,10 @@ Postgres.prototype.getQuery = function(queryNode) {
     this.params = [];
     this._disableParameterPlaceholders = previousFlagStatus;
   }
-  
+
   // create the query object
   var query = { text: this.output.join(' '), values: this.params };
-   
+
   // reset the internal state of this builder
   this.output = [];
   this.params = [];
@@ -154,7 +155,7 @@ Postgres.prototype.visit = function(node) {
     case 'FUNCTION CALL'   : return this.visitFunctionCall(node);
     case 'ARRAY CALL'      : return this.visitArrayCall(node);
     case 'CREATE VIEW'     : return this.visitCreateView(node);
-    
+
     case 'POSTFIX UNARY' : return this.visitPostfixUnary(node);
     case 'PREFIX UNARY'  : return this.visitPrefixUnary(node);
     case 'BINARY'        : return this.visitBinary(node);
@@ -371,6 +372,9 @@ Postgres.prototype.visitWhere = function(where) {
 
 Postgres.prototype.visitOrderBy = function(orderBy) {
   var result = ['ORDER BY', orderBy.nodes.map(this.visit.bind(this)).join(', ')];
+  if (this._myClass === Postgres && this.config.nullsLast) {
+      result.push('NULLS LAST');
+  }
   return result;
 };
 

--- a/test/dialects/order-tests.js
+++ b/test/dialects/order-tests.js
@@ -253,3 +253,59 @@ Harness.test({
   },
   params: []
 });
+
+Harness.test({
+  query: post.select(post.content).order(post.content.descending),
+  pg: {
+    text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" DESC NULLS LAST',
+    string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" DESC NULLS LAST',
+    config: {
+        nullsLast: true
+    }
+  },
+  sqlite: {
+    text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" DESC',
+    string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" DESC'
+  },
+  mysql: {
+    text  : 'SELECT `post`.`content` FROM `post` ORDER BY `post`.`content` DESC',
+    string: 'SELECT `post`.`content` FROM `post` ORDER BY `post`.`content` DESC'
+  },
+  mssql: {
+    text  : 'SELECT [post].[content] FROM [post] ORDER BY [post].[content] DESC',
+    string: 'SELECT [post].[content] FROM [post] ORDER BY [post].[content] DESC'
+  },
+  oracle: {
+    text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" DESC',
+    string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" DESC'
+  },
+  params: []
+});
+
+Harness.test({
+  query: post.select(post.content).order(post.content),
+  pg: {
+    text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" NULLS LAST',
+    string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" NULLS LAST',
+    config: {
+        nullsLast: true
+    }
+  },
+  sqlite: {
+    text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content"',
+    string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content"'
+  },
+  mysql: {
+    text  : 'SELECT `post`.`content` FROM `post` ORDER BY `post`.`content`',
+    string: 'SELECT `post`.`content` FROM `post` ORDER BY `post`.`content`'
+  },
+  mssql: {
+    text  : 'SELECT [post].[content] FROM [post] ORDER BY [post].[content]',
+    string: 'SELECT [post].[content] FROM [post] ORDER BY [post].[content]'
+  },
+  oracle: {
+    text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content"',
+    string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content"'
+  },
+  params: []
+});

--- a/test/dialects/order-tests.js
+++ b/test/dialects/order-tests.js
@@ -260,7 +260,7 @@ Harness.test({
     text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" DESC NULLS LAST',
     string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" DESC NULLS LAST',
     config: {
-        nullsLast: true
+        nullOrder: "last"
     }
   },
   sqlite: {
@@ -288,7 +288,35 @@ Harness.test({
     text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" NULLS LAST',
     string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" NULLS LAST',
     config: {
-        nullsLast: true
+        nullOrder: "last"
+    }
+  },
+  sqlite: {
+    text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content"',
+    string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content"'
+  },
+  mysql: {
+    text  : 'SELECT `post`.`content` FROM `post` ORDER BY `post`.`content`',
+    string: 'SELECT `post`.`content` FROM `post` ORDER BY `post`.`content`'
+  },
+  mssql: {
+    text  : 'SELECT [post].[content] FROM [post] ORDER BY [post].[content]',
+    string: 'SELECT [post].[content] FROM [post] ORDER BY [post].[content]'
+  },
+  oracle: {
+    text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content"',
+    string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content"'
+  },
+  params: []
+});
+
+Harness.test({
+  query: post.select(post.content).order(post.content.asc),
+  pg: {
+    text  : 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" NULLS FIRST',
+    string: 'SELECT "post"."content" FROM "post" ORDER BY "post"."content" NULLS FIRST',
+    config: {
+        nullOrder: "first"
     }
   },
   sqlite: {


### PR DESCRIPTION
Since the configuration object is now available to each dialect, I have added a configuration for postgres allowing the user to specify that NULLS should appear in a specific order. This is achieved through the 'NULLS FIRST'/'NULLS LAST' operators described [here](http://www.postgresql.org/docs/9.4/static/queries-order.html). We ran into an issue where nulls were returned in different orders between databases, and Postgres seems to be the odd man out with the ability at query time to control where NULLs land. This configuration allows us to achieve consistency across DBMS.