### PR TITLE
Tables with "alias" as a column name error on word.replace

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -689,7 +689,7 @@ Postgres.prototype.visitTable = function(tableNode) {
     txt += '.';
   }
   txt += this.quote(table.getName());
-  if(table.alias) {
+  if(typeof table.alias === 'string') {
     txt += this._aliasText + this.quote(table.alias);
   }
   return [txt];

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -729,7 +729,7 @@ Postgres.prototype.visitColumn = function(columnNode) {
     }
   }
   if(!inInsertUpdateClause && !this.visitingReturning && !this._visitingCreate && !this._visitingAlter && !columnNode.subfieldContainer) {
-    if(table.alias) {
+    if(typeof table.alias === 'string') {
       txt.push(this.quote(table.alias));
     } else {
       if(table.getSchema()) {

--- a/test/column-tests.js
+++ b/test/column-tests.js
@@ -6,7 +6,7 @@ var sql = require(__dirname + '/../lib');
 describe('column', function() {
   var table = sql.define({
     name: 'user',
-    columns: ['id', 'created']
+    columns: ['id', 'created', 'alias']
   });
 
   it('can be accessed by property and array', function() {
@@ -16,6 +16,10 @@ describe('column', function() {
   describe('toQuery()', function() {
     it('works', function() {
       assert.equal(table.id.toQuery().text, '"user"."id"');
+    });
+
+    it('works with a column name of "alias"', function() {
+      assert.equal(table.alias.toQuery().text, '"user"."alias"');
     });
 
     it('respects AS rename', function() {


### PR DESCRIPTION
In the instance of a table with a column value of "alias" [word.replace](https://github.com/brianc/node-sql/blob/master/lib/dialect/postgres.js#L192) will error due to "alias", at this point, is an object.

A slight modification to the property check [here](https://github.com/brianc/node-sql/compare/master...iamcharliegoddard:fix-alias-as-column-name#diff-441b873f400aa79e8bd24fb525f0fb1cR732) from:
```JavaScript
    if(table.alias) {
      txt.push(this.quote(table.alias));
    } else {
    }
```
to
```JavaScript
    if(typeof table.alias === 'string') {
      txt.push(this.quote(table.alias));
    } else {
    }
```

Seems to have remedy the issue.

Thoughts?
