### PR TITLE
Use ? for placeholder in mssql dialect

### DIFF
--- a/lib/dialect/mssql.js
+++ b/lib/dialect/mssql.js
@@ -6,6 +6,14 @@
 var util = require('util');
 var assert = require('assert');
 
+/**
+ * Config can contain:
+ *
+ * questionMarkParameterPlaceholder:true which will use a "?" for the parameter placeholder instead of the @index.
+ *
+ * @param config
+ * @constructor
+ */
 var Mssql = function(config) {
   this.output = [];
   this.params = [];
@@ -23,6 +31,7 @@ Mssql.prototype._quoteCharacter = '[';
 Mssql.prototype._arrayAggFunctionName = '';
 
 Mssql.prototype._getParameterPlaceholder = function(index, value) {
+	if (this.config.questionMarkParameterPlaceholder) return '?';
   return '@' + index;
 };
 

--- a/test/index-tests.js
+++ b/test/index-tests.js
@@ -195,4 +195,20 @@ suite('index', function() {
     });
   });
 
+  test('mssql default parameter place holder is @index', function() {
+    var Sql = sql.Sql;
+    var mssql = new Sql('mssql');
+    var query = mssql.select(user.id).from(user).where(user.email.equals('x@y.com')).toQuery();
+    assert.equal(query.text, 'SELECT [user].[id] FROM [user] WHERE ([user].[email] = @1)');
+    assert.equal(query.values[0], 'x@y.com');
+  });
+
+  test('mssql override default parameter placeholder with ?', function() {
+    var Sql = sql.Sql;
+    var mssql = new Sql('mssql',{questionMarkParameterPlaceholder:true});
+    var query = mssql.select(user.id).from(user).where(user.email.equals('x@y.com')).toQuery();
+    assert.equal(query.text, 'SELECT [user].[id] FROM [user] WHERE ([user].[email] = ?)');
+    assert.equal(query.values[0], 'x@y.com');
+  });
+
 });


### PR DESCRIPTION
Adds ability to override the default parameter place holder of @index and use ? instead. Addresses #285.

This can be used by adding `questionMarkParameterPlaceholder:true` to the config when setting the dialect like so:

```
var sql = require("sql")
sql.setDialect("mssql",{questionMarkParameterPlaceholder:true})
```