### PR TITLE
Fixed PostgreSQL array insertion syntax.

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -41,9 +41,10 @@ Postgres.prototype._getParameterValue = function(value, quoteChar) {
   } else if ('object' === typeof value) {
     if (_.isArray(value)) {
       // convert each element of the array
+      var self = this;
       value = value.map(function (item) {
           // In a Postgres array, strings must be double-quoted
-          return this._getParameterValue(item, '"');
+          return self._getParameterValue(item, '"');
       });
       value = '\'{' + value.join(',') + '}\'';
     } else if (_.isFunction(value.toISOString)) {

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -41,8 +41,8 @@ Postgres.prototype._getParameterValue = function(value, quoteChar) {
   } else if ('object' === typeof value) {
     if (_.isArray(value)) {
       // convert each element of the array
-      var self = this;
       if (this._myClass === Postgres) {
+        var self = this;
         value = value.map(function (item) {
             // In a Postgres array, strings must be double-quoted
             return self._getParameterValue(item, '"');

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -26,7 +26,7 @@ Postgres.prototype._getParameterText = function(index, value) {
   }
 };
 
-Postgres.prototype._getParameterValue = function(value) {
+Postgres.prototype._getParameterValue = function(value, quoteChar) {
   // handle primitives
   if (null === value) {
     value = 'NULL';
@@ -36,12 +36,15 @@ Postgres.prototype._getParameterValue = function(value) {
     // number is just number
     value = value;
   } else if ('string' === typeof value) {
-    // string uses single quote
-    value = this.quote(value, "'");
+    // string uses single quote by default
+    value = this.quote(value, quoteChar || "'");
   } else if ('object' === typeof value) {
     if (_.isArray(value)) {
       // convert each element of the array
-      value = _.map(value, this._getParameterValue, this);
+      value = value.map(function (item) {
+          // In a Postgres array, strings must be double-quoted
+          return this._getParameterValue(item, '"');
+      });
       value = '\'{' + value.join(',') + '}\'';
     } else if (_.isFunction(value.toISOString)) {
       // Date object's default toString format does not get parsed well

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -42,7 +42,7 @@ Postgres.prototype._getParameterValue = function(value) {
     if (_.isArray(value)) {
       // convert each element of the array
       value = _.map(value, this._getParameterValue, this);
-      value = '{' + value.join(', ') + '}';
+      value = '\'{' + value.join(',') + '}\'';
     } else if (_.isFunction(value.toISOString)) {
       // Date object's default toString format does not get parsed well
       // Handle date like objects using toISOString

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -42,7 +42,7 @@ Postgres.prototype._getParameterValue = function(value) {
     if (_.isArray(value)) {
       // convert each element of the array
       value = _.map(value, this._getParameterValue, this);
-      value = '(' + value.join(', ') + ')';
+      value = '{' + value.join(', ') + '}';
     } else if (_.isFunction(value.toISOString)) {
       // Date object's default toString format does not get parsed well
       // Handle date like objects using toISOString

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -42,11 +42,16 @@ Postgres.prototype._getParameterValue = function(value, quoteChar) {
     if (_.isArray(value)) {
       // convert each element of the array
       var self = this;
-      value = value.map(function (item) {
-          // In a Postgres array, strings must be double-quoted
-          return self._getParameterValue(item, '"');
-      });
-      value = '\'{' + value.join(',') + '}\'';
+      if (this._myClass === Postgres) {
+        value = value.map(function (item) {
+            // In a Postgres array, strings must be double-quoted
+            return self._getParameterValue(item, '"');
+        });
+        value = '\'{' + value.join(',') + '}\'';
+      } else {
+        value = _.map(value, this._getParameterValue, this);
+        value = '(' + value.join(', ') + ')';
+      }
     } else if (_.isFunction(value.toISOString)) {
       // Date object's default toString format does not get parsed well
       // Handle date like objects using toISOString

--- a/test/dialects/insert-tests.js
+++ b/test/dialects/insert-tests.js
@@ -1,8 +1,14 @@
 'use strict';
 
+var Table = require(__dirname + '/../../lib/table');
 var Harness = require('./support');
 var post = Harness.definePostTable();
 var user = Harness.defineUserTable();
+
+var arrayTable = Table.define({
+    name: 'arraytest',
+    columns: ['id', 'numbers']
+});
 
 Harness.test({
   query: post.insert(post.content.value('test'), post.userId.value(1)),
@@ -629,4 +635,44 @@ Harness.test({
     string: 'SELECT `post`.* FROM `post` WHERE (1=2)'
   },
   params: []
+});
+
+Harness.test({
+  query: arrayTable.insert(arrayTable.id.value(1), arrayTable.numbers.value([2, 3, 4])),
+  pg: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES ($1, $2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, \'{2,3,4}\')'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES ($1, $2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, (2, 3, 4))'
+  },
+  mysql: {
+    text  : 'INSERT INTO `arraytest` (`id`, `numbers`) VALUES (?, ?)',
+    string: 'INSERT INTO `arraytest` (`id`, `numbers`) VALUES (1, (2, 3, 4))'
+  },
+  oracle: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES (:1, :2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, (2, 3, 4))'
+  }
+});
+
+Harness.test({
+  query: arrayTable.insert(arrayTable.id.value(1), arrayTable.numbers.value(["one", "two", "three"])),
+  pg: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES ($1, $2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, \'{"one","two","three"}\')'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES ($1, $2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, (\'one\', \'two\', \'three\'))'
+  },
+  mysql: {
+    text  : 'INSERT INTO `arraytest` (`id`, `numbers`) VALUES (?, ?)',
+    string: 'INSERT INTO `arraytest` (`id`, `numbers`) VALUES (1, (\'one\', \'two\', \'three\'))'
+  },
+  oracle: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES (:1, :2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, (\'one\', \'two\', \'three\'))'
+  }
 });


### PR DESCRIPTION
Postgres supports arrays natively, but they were not being created properly with the handling of arrays in the Postgres dialect. According to the [current documentation](http://www.postgresql.org/docs/current/static/arrays.html) arrays are wrapped as a string (single quoted), with brackets, and each string (if the elements are strings) is double quoted. This PR updates the handling of arrays (for Postgres only) to match what the db expects.