### PR TITLE
Fix booleans and objects

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -51,7 +51,8 @@ Postgres.prototype._getParameterValue = function(value) {
       value = this._getParameterValue('\\x' + value.toString('hex'));
     } else {
       // rich object represent with string
-      value = this._getParameterValue(value.toString());
+      var strValue = value.toString();
+      value = strValue === '[object Object]' ? this._getParameterValue(JSON.stringify(value)) : this._getParameterValue(strValue);
     }
   } else {
     throw new Error('Unable to use ' + value + ' in query');

--- a/lib/dialect/sqlite.js
+++ b/lib/dialect/sqlite.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var util = require('util');
 var assert = require('assert');
 
@@ -23,6 +24,10 @@ Sqlite.prototype._getParameterValue = function(value) {
     value = 'x' + this._getParameterValue(value.toString('hex'));
   } else if (value instanceof Date && this.config.dateTimeMillis) {
     value = value.getTime();
+  } else if('boolean' === typeof value) {
+    value = value ? 1 : 0;
+  } else if(_.isArray(value)) {
+    value = Postgres.prototype._getParameterValue.call(this, JSON.stringify(value));
   } else {
     value = Postgres.prototype._getParameterValue.call(this, value);
   }

--- a/test/dialects/case-tests.js
+++ b/test/dialects/case-tests.js
@@ -12,7 +12,7 @@ Harness.test({
   },
   sqlite: {
     text  : 'SELECT (CASE WHEN $1 THEN $2 WHEN $3 THEN $4 ELSE $5 END) FROM "customer"',
-    string: 'SELECT (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE 2 END) FROM "customer"'
+    string: 'SELECT (CASE WHEN 1 THEN 0 WHEN 0 THEN 1 ELSE 2 END) FROM "customer"'
   },
   mysql: {
     text  : 'SELECT (CASE WHEN ? THEN ? WHEN ? THEN ? ELSE ? END) FROM `customer`',
@@ -40,7 +40,7 @@ Harness.test({
   },
   sqlite: {
     text  : 'SELECT ("customer"."age" + (CASE WHEN $1 THEN $2 WHEN $3 THEN $4 ELSE $5 END)) FROM "customer"',
-    string: 'SELECT ("customer"."age" + (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE 2 END)) FROM "customer"'
+    string: 'SELECT ("customer"."age" + (CASE WHEN 1 THEN 0 WHEN 0 THEN 1 ELSE 2 END)) FROM "customer"'
   },
   mysql: {
     text  : 'SELECT (`customer`.`age` + (CASE WHEN ? THEN ? WHEN ? THEN ? ELSE ? END)) FROM `customer`',
@@ -68,7 +68,7 @@ Harness.test({
   },
   sqlite: {
     text  : 'SELECT ((CASE WHEN $1 THEN $2 WHEN $3 THEN $4 ELSE $5 END) + $6) FROM "customer"',
-    string: 'SELECT ((CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE 2 END) + 3) FROM "customer"'
+    string: 'SELECT ((CASE WHEN 1 THEN 0 WHEN 0 THEN 1 ELSE 2 END) + 3) FROM "customer"'
   },
   mysql: {
     text  : 'SELECT ((CASE WHEN ? THEN ? WHEN ? THEN ? ELSE ? END) + ?) FROM `customer`',
@@ -96,7 +96,7 @@ Harness.test({
   },
   sqlite: {
     text  : 'SELECT (CASE WHEN $1 THEN $2 WHEN $3 THEN $4 ELSE ("customer"."age" BETWEEN $5 AND $6) END) FROM "customer"',
-    string: 'SELECT (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 ELSE ("customer"."age" BETWEEN 10 AND 20) END) FROM "customer"'
+    string: 'SELECT (CASE WHEN 1 THEN 0 WHEN 0 THEN 1 ELSE ("customer"."age" BETWEEN 10 AND 20) END) FROM "customer"'
   },
   mysql: {
     text  : 'SELECT (CASE WHEN ? THEN ? WHEN ? THEN ? ELSE (`customer`.`age` BETWEEN ? AND ?) END) FROM `customer`',
@@ -124,7 +124,7 @@ Harness.test({
   },
   sqlite: {
     text  : 'SELECT (CASE WHEN $1 THEN $2 WHEN $3 THEN $4 END) FROM "customer"',
-    string: 'SELECT (CASE WHEN TRUE THEN 0 WHEN FALSE THEN 1 END) FROM "customer"'
+    string: 'SELECT (CASE WHEN 1 THEN 0 WHEN 0 THEN 1 END) FROM "customer"'
   },
   mysql: {
     text  : 'SELECT (CASE WHEN ? THEN ? WHEN ? THEN ? END) FROM `customer`',

--- a/test/dialects/update-tests.js
+++ b/test/dialects/update-tests.js
@@ -3,6 +3,7 @@
 var Harness = require('./support');
 var post = Harness.definePostTable();
 var user = Harness.defineUserTable();
+var variable = Harness.defineVariableTable();
 
 Harness.test({
   query: post.update({
@@ -192,4 +193,54 @@ Harness.test({
     string: 'UPDATE "post" SET "content" = utl_raw.cast_to_varchar2(hextoraw(\'74657374\'))'
   },
   params: [new Buffer('test')]
+});
+
+// Boolean updates
+Harness.test({
+  query: variable.update({
+    a: true,
+    b: false
+  }),
+  pg: {
+    text  : 'UPDATE "variable" SET "a" = $1, "b" = $2',
+    string: 'UPDATE "variable" SET "a" = TRUE, "b" = FALSE'
+  },
+  sqlite: {
+    text  : 'UPDATE "variable" SET "a" = $1, "b" = $2',
+    string: 'UPDATE "variable" SET "a" = 1, "b" = 0'
+  },
+  mysql: {
+    text  : 'UPDATE `variable` SET `a` = ?, `b` = ?',
+    string: 'UPDATE `variable` SET `a` = TRUE, `b` = FALSE'
+  },
+  oracle: {
+    text  : 'UPDATE "variable" SET "a" = :1, "b" = :2',
+    string: 'UPDATE "variable" SET "a" = TRUE, "b" = FALSE'
+  },
+  params: [true, false]
+});
+
+// Object updates
+Harness.test({
+  query: variable.update({
+    a: {"id": 1, "value": 2},
+    b: [{"id": 2, "value": 3}, {"id": 3, "value": 4}]
+  }),
+  pg: {
+    text  : 'UPDATE "variable" SET "a" = $1, "b" = $2',
+    string: 'UPDATE "variable" SET "a" = \'{"id":1,"value":2}\', "b" = (\'{"id":2,"value":3}\', \'{"id":3,"value":4}\')'
+  },
+  sqlite: {
+    text  : 'UPDATE "variable" SET "a" = $1, "b" = $2',
+    string: 'UPDATE "variable" SET "a" = \'{"id":1,"value":2}\', "b" = \'[{"id":2,"value":3},{"id":3,"value":4}]\''
+  },
+  mysql: {
+    text  : 'UPDATE `variable` SET `a` = ?, `b` = ?',
+    string: 'UPDATE `variable` SET `a` = \'{"id":1,"value":2}\', `b` = (\'{"id":2,"value":3}\', \'{"id":3,"value":4}\')'
+  },
+  oracle: {
+    text  : 'UPDATE "variable" SET "a" = :1, "b" = :2',
+    string: 'UPDATE "variable" SET "a" = \'{"id":1,"value":2}\', "b" = (\'{"id":2,"value":3}\', \'{"id":3,"value":4}\')'
+  },
+  params: [{"id": 1, "value": 2}, [{"id": 2, "value": 3}, {"id": 3, "value": 4}]]
 });


### PR DESCRIPTION
Sqlite doesn't support TRUE and FALSE as boolean values, only 1 and 0.

Also, if trying to update using a JSON object, if the object didn't have an explicit .toString() method, it would end up trying to save '[object Object]' to the database.  Switched out to use JSON.stringify in that case.