### PR TITLE
Second attempt at fixing Postgres arrays

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -26,7 +26,7 @@ Postgres.prototype._getParameterText = function(index, value) {
   }
 };
 
-Postgres.prototype._getParameterValue = function(value) {
+Postgres.prototype._getParameterValue = function(value, quoteChar) {
   // handle primitives
   if (null === value) {
     value = 'NULL';
@@ -36,8 +36,8 @@ Postgres.prototype._getParameterValue = function(value) {
     // number is just number
     value = value;
   } else if ('string' === typeof value) {
-    // string uses single quote
-    value = this.quote(value, "'");
+    // string uses single quote by default
+    value = this.quote(value, quoteChar || "'");
   } else if ('object' === typeof value) {
     if (_.isArray(value)) {
       if (this._myClass === Postgres) {

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -40,9 +40,25 @@ Postgres.prototype._getParameterValue = function(value) {
     value = this.quote(value, "'");
   } else if ('object' === typeof value) {
     if (_.isArray(value)) {
-      // convert each element of the array
-      value = _.map(value, this._getParameterValue, this);
-      value = '(' + value.join(', ') + ')';
+      if (this._myClass === Postgres) {
+        // naive check to see if this is an array of objects, which
+        // is handled differently than an array of primitives
+        if (value.length && 'object' === typeof value[0] &&
+            !_.isFunction(value[0].toISOString) &&
+            !_.isArray(value[0])) {
+            value = "'" + JSON.stringify(value) + "'";
+        } else {
+            var self = this;
+            value = value.map(function (item) {
+                // In a Postgres array, strings must be double-quoted
+                return self._getParameterValue(item, '"');
+            });
+            value = '\'{' + value.join(',') + '}\'';
+        }
+      } else {
+        value = _.map(value, this._getParameterValue, this);
+        value = '(' + value.join(', ') + ')';
+      }
     } else if (_.isFunction(value.toISOString)) {
       // Date object's default toString format does not get parsed well
       // Handle date like objects using toISOString

--- a/test/dialects/insert-tests.js
+++ b/test/dialects/insert-tests.js
@@ -4,7 +4,7 @@ var Harness = require('./support');
 var post = Harness.definePostTable();
 var user = Harness.defineUserTable();
 
-var arrayTable = Table.define({
+var arrayTable = require('../../lib/table').define({
     name: 'arraytest',
     columns: ['id', 'numbers']
 });

--- a/test/dialects/insert-tests.js
+++ b/test/dialects/insert-tests.js
@@ -4,6 +4,11 @@ var Harness = require('./support');
 var post = Harness.definePostTable();
 var user = Harness.defineUserTable();
 
+var arrayTable = Table.define({
+    name: 'arraytest',
+    columns: ['id', 'numbers']
+});
+
 Harness.test({
   query: post.insert(post.content.value('test'), post.userId.value(1)),
   pg: {
@@ -629,4 +634,44 @@ Harness.test({
     string: 'SELECT `post`.* FROM `post` WHERE (1=2)'
   },
   params: []
+});
+
+Harness.test({
+  query: arrayTable.insert(arrayTable.id.value(1), arrayTable.numbers.value([2, 3, 4])),
+  pg: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES ($1, $2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, \'{2,3,4}\')'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES ($1, $2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, \'[2,3,4]\')'
+  },
+  mysql: {
+    text  : 'INSERT INTO `arraytest` (`id`, `numbers`) VALUES (?, ?)',
+    string: 'INSERT INTO `arraytest` (`id`, `numbers`) VALUES (1, (2, 3, 4))'
+  },
+  oracle: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES (:1, :2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, (2, 3, 4))'
+  }
+});
+
+Harness.test({
+  query: arrayTable.insert(arrayTable.id.value(1), arrayTable.numbers.value(["one", "two", "three"])),
+  pg: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES ($1, $2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, \'{"one","two","three"}\')'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES ($1, $2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, \'["one","two","three"]\')'
+  },
+  mysql: {
+    text  : 'INSERT INTO `arraytest` (`id`, `numbers`) VALUES (?, ?)',
+    string: 'INSERT INTO `arraytest` (`id`, `numbers`) VALUES (1, (\'one\', \'two\', \'three\'))'
+  },
+  oracle: {
+    text  : 'INSERT INTO "arraytest" ("id", "numbers") VALUES (:1, :2)',
+    string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, (\'one\', \'two\', \'three\'))'
+  }
 });

--- a/test/dialects/update-tests.js
+++ b/test/dialects/update-tests.js
@@ -228,7 +228,7 @@ Harness.test({
   }),
   pg: {
     text  : 'UPDATE "variable" SET "a" = $1, "b" = $2',
-    string: 'UPDATE "variable" SET "a" = \'{"id":1,"value":2}\', "b" = (\'{"id":2,"value":3}\', \'{"id":3,"value":4}\')'
+    string: 'UPDATE "variable" SET "a" = \'{"id":1,"value":2}\', "b" = \'[{"id":2,"value":3},{"id":3,"value":4}]\''
   },
   sqlite: {
     text  : 'UPDATE "variable" SET "a" = $1, "b" = $2',


### PR DESCRIPTION
@brianc I figured out the issue with the tests. @barryhammen had added some tests for arrays and modified the way that arrays were serialized with SQLite, which threw off a couple of my tests. I also found that the way arrays of objects were being serialized was not supported by postgres, so I've added a little bit of logic to check if the array being serialized is an array of objects, and if so just giving it to postgres as a JSON.stringified array (which is valid). This check is pretty naive and doesn't work for situations where you have a complex and deeply nested array of objects, but I think it handles the 99% use case.

Let me know what you think!