### PR TITLE
Extend query with value expressions

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -644,7 +644,8 @@ Postgres.prototype.visitQuery = function(queryNode) {
     actions.push(new Select().add('*'));
     isSelect = true;
   }
-  if(missingFrom) {
+  if(missingFrom && queryNode.table instanceof Table) {
+	  // the instanceof handles the situation where a sql.select(some expression) is used and there should be no FROM clause
     targets.push(new From().add(queryNode.table));
   }
   if (createView) {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -15,7 +15,11 @@ Node.prototype.toNode = function() {
 
 Node.prototype.add = function(node) {
   assert(node, 'Error while trying to add a non-existant node to a query');
-  this.nodes.push(typeof node === 'string' ? new TextNode(node) : node.toNode());
+	var newNode
+  if (typeof node === 'string') newNode = new TextNode(node)
+  else if (node.toNode) newNode = node.toNode()
+  else newNode = node
+  this.nodes.push(newNode);
   return this;
 };
 

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -15,10 +15,10 @@ Node.prototype.toNode = function() {
 
 Node.prototype.add = function(node) {
   assert(node, 'Error while trying to add a non-existant node to a query');
-	var newNode
-  if (typeof node === 'string') newNode = new TextNode(node)
-  else if (node.toNode) newNode = node.toNode()
-  else newNode = node
+	var newNode;
+  if (typeof node === 'string') newNode = new TextNode(node);
+  else if (node.toNode) newNode = node.toNode();
+  else newNode = node;
   this.nodes.push(newNode);
   return this;
 };

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var _ = require('lodash');
 var assert = require('assert');
 var sliced = require('sliced');
 var util   = require('util');
+var valueExpressionMixin = require(__dirname + '/valueExpression');
 
 var Node            = require('./');
 var Select          = require('./select');
@@ -477,5 +479,17 @@ var Query = Node.define({
     return this;
   }
 });
+
+// Here we are extending query with valueExpressions so that it's possible to write queries like
+//   var query=sql.select(a.select(a.x.sum()).plus(b.select(b.y.sum()))
+// which generates:
+//   SELECT (SELECT SUM(a.x) FROM a) + (SELECT SUM(b.y) FROM b)
+// We need to remove "or" and "and" from here because it conflicts with the already existing functionality of appending
+// to the where clause like so:
+//   var query=a.select().where(a.name.equals("joe")).or(a.name.equals("sam"))
+var valueExpressions=valueExpressionMixin();
+delete valueExpressions["or"];
+delete valueExpressions["and"];
+_.extend(Query.prototype, valueExpressions);
 
 module.exports = Query;

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -488,8 +488,8 @@ var Query = Node.define({
 // to the where clause like so:
 //   var query=a.select().where(a.name.equals("joe")).or(a.name.equals("sam"))
 var valueExpressions=valueExpressionMixin();
-delete valueExpressions["or"];
-delete valueExpressions["and"];
+delete valueExpressions.or;
+delete valueExpressions.and;
 _.extend(Query.prototype, valueExpressions);
 
 module.exports = Query;

--- a/test/dialects/select-tests.js
+++ b/test/dialects/select-tests.js
@@ -3,6 +3,7 @@
 var Harness = require('./support');
 var post = Harness.definePostTable();
 var customerAlias = Harness.defineCustomerAliasTable();
+var Sql = require('../../lib');
 
 Harness.test({
   query: post.select(post.id).select(post.content),
@@ -50,6 +51,107 @@ Harness.test({
   oracle: {
     text  : 'SELECT "customer"."id" "id_alias", "customer"."name" "name_alias", "customer"."age" "age_alias", "customer"."income" "income_alias", "customer"."metadata" "metadata_alias" FROM "customer"',
     string: 'SELECT "customer"."id" "id_alias", "customer"."name" "name_alias", "customer"."age" "age_alias", "customer"."income" "income_alias", "customer"."metadata" "metadata_alias" FROM "customer"'
+  },
+  params: []
+});
+
+// Test that we can generate a SELECT claus without a FROM clause
+Harness.test({
+  query: Sql.select(),
+  pg: {
+    text  : 'SELECT ',
+    string: 'SELECT '
+  },
+  sqlite: {
+    text  : 'SELECT ',
+    string: 'SELECT '
+  },
+  mysql: {
+    text  : 'SELECT ',
+    string: 'SELECT '
+  },
+  mssql: {
+    text  : 'SELECT ',
+    string: 'SELECT '
+  },
+  oracle: {
+    text  : 'SELECT ',
+    string: 'SELECT '
+  },
+  params: []
+});
+
+Harness.test({
+  query: Sql.select("1").where("1=1"),
+  pg: {
+    text  : 'SELECT 1 WHERE (1=1)',
+    string: 'SELECT 1 WHERE (1=1)'
+  },
+  sqlite: {
+    text  : 'SELECT 1 WHERE (1=1)',
+    string: 'SELECT 1 WHERE (1=1)'
+  },
+  mysql: {
+    text  : 'SELECT 1 WHERE (1=1)',
+    string: 'SELECT 1 WHERE (1=1)'
+  },
+  mssql: {
+    text  : 'SELECT 1 WHERE (1=1)',
+    string: 'SELECT 1 WHERE (1=1)'
+  },
+  oracle: {
+    text  : 'SELECT 1 WHERE (1=1)',
+    string: 'SELECT 1 WHERE (1=1)'
+  },
+  params: []
+});
+
+Harness.test({
+  query: Sql.select(post.select(post.id)),
+  pg: {
+    text  : 'SELECT (SELECT "post"."id" FROM "post")',
+    string: 'SELECT (SELECT "post"."id" FROM "post")'
+  },
+  sqlite: {
+    text  : 'SELECT (SELECT "post"."id" FROM "post")',
+    string: 'SELECT (SELECT "post"."id" FROM "post")'
+  },
+  mysql: {
+    text  : 'SELECT (SELECT `post`.`id` FROM `post`)',
+    string: 'SELECT (SELECT `post`.`id` FROM `post`)'
+  },
+  mssql: {
+    text  : 'SELECT (SELECT [post].[id] FROM [post])',
+    string: 'SELECT (SELECT [post].[id] FROM [post])'
+  },
+  oracle: {
+    text  : 'SELECT (SELECT "post"."id" FROM "post")',
+    string: 'SELECT (SELECT "post"."id" FROM "post")'
+  },
+  params: []
+});
+
+Harness.test({
+  query: Sql.select(post.select(post.content).plus(post.select(post.content))),
+  pg: {
+    text  : 'SELECT ((SELECT "post"."content" FROM "post") + (SELECT "post"."content" FROM "post"))',
+    string: 'SELECT ((SELECT "post"."content" FROM "post") + (SELECT "post"."content" FROM "post"))'
+  },
+  sqlite: {
+    text  : 'SELECT ((SELECT "post"."content" FROM "post") + (SELECT "post"."content" FROM "post"))',
+    string: 'SELECT ((SELECT "post"."content" FROM "post") + (SELECT "post"."content" FROM "post"))'
+  },
+  mysql: {
+    text  : 'SELECT ((SELECT `post`.`content` FROM `post`) + (SELECT `post`.`content` FROM `post`))',
+    string: 'SELECT ((SELECT `post`.`content` FROM `post`) + (SELECT `post`.`content` FROM `post`))'
+  },
+  mssql: {
+    text  : 'SELECT ((SELECT [post].[content] FROM [post]) + (SELECT [post].[content] FROM [post]))',
+    string: 'SELECT ((SELECT [post].[content] FROM [post]) + (SELECT [post].[content] FROM [post]))'
+  },
+  oracle: {
+    text  : 'SELECT ((SELECT "post"."content" FROM "post") + (SELECT "post"."content" FROM "post"))',
+    string: 'SELECT ((SELECT "post"."content" FROM "post") + (SELECT "post"."content" FROM "post"))'
   },
   params: []
 });

--- a/test/dialects/select-tests.js
+++ b/test/dialects/select-tests.js
@@ -81,6 +81,32 @@ Harness.test({
   params: []
 });
 
+// Test that we can generate a SELECT claus without a FROM clause
+Harness.test({
+  query: Sql.select("1"),
+  pg: {
+    text  : 'SELECT 1',
+    string: 'SELECT 1'
+  },
+  sqlite: {
+    text  : 'SELECT 1',
+    string: 'SELECT 1'
+  },
+  mysql: {
+    text  : 'SELECT 1',
+    string: 'SELECT 1'
+  },
+  mssql: {
+    text  : 'SELECT 1',
+    string: 'SELECT 1'
+  },
+  oracle: {
+    text  : 'SELECT 1',
+    string: 'SELECT 1'
+  },
+  params: []
+});
+
 Harness.test({
   query: Sql.select("1").where("1=1"),
   pg: {


### PR DESCRIPTION
These changes allow for the writing of statements like:
```javascript
var sql=require("sql")
var query=sql.select(a.select(a.col.sum()).plus(b.select(b.col.sum()))
```
which generates:
```sql
SELECT (SELECT SUM(a.col) FROM a) + (SELECT SUM(b.col) FROM b)
```
A side effect is that it also allows for writing `SELECT ` statements without a from clause like:
```javascript
var query=sql.select("1")
```
which generates:
```sql
SELECT 1
```