### PR TITLE
INSERT INTO ... SELECT create with .add()

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -596,7 +596,7 @@ Postgres.prototype.visitOverlap = function(overlap) {
 };
 
 Postgres.prototype.visitQuery = function(queryNode) {
-  if (this._queryNode) return this.visitSubquery(queryNode);
+  if (this._queryNode) return this.visitSubquery(queryNode,dontParenthesizeSubQuery(this._queryNode));
   this._queryNode = queryNode;
   // need to sort the top level query nodes on visitation priority
   // so select/insert/update/delete comes before from comes before where
@@ -678,7 +678,7 @@ Postgres.prototype.visitQueryHelper=function(actions,targets,filters){
   return this.output;
 };
 
-Postgres.prototype.visitSubquery = function(queryNode) {
+Postgres.prototype.visitSubquery = function(queryNode,dontParenthesize) {
   // create another query builder of the current class to build the subquery
   var subQuery = new this._myClass(this.config);
 
@@ -696,6 +696,9 @@ Postgres.prototype.visitSubquery = function(queryNode) {
   }
 
   var alias = queryNode.alias;
+  if (dontParenthesize) {
+  	return [subQuery.output.join(' ') + (alias ? ' ' + this.quote(alias) : '')];
+  }
   return ['(' + subQuery.output.join(' ') + ')' + (alias ? ' ' + this.quote(alias) : '')];
 };
 
@@ -1040,5 +1043,23 @@ Postgres.prototype.handleDistinct = function(actions,filters) {
   // mark the SELECT node that it's distinct
   selectInfo.node.isDistinct = true;
 };
+
+/**
+ * If the parent of the subquery is an INSERT we don't want to parenthesize.
+ * This happens when you create the query like so:
+ *
+ * var query=post.insert(post.id)
+ * var select=user.select(user.id)
+ * query.add(select)
+ *
+ * @param parentQuery
+ * @returns {boolean}
+ */
+function dontParenthesizeSubQuery(parentQuery){
+	if (!parentQuery) return false;
+	if (parentQuery.nodes.length == 0) return false;
+	if (parentQuery.nodes[0].type != 'INSERT') return false;
+	return true;
+}
 
 module.exports = Postgres;

--- a/test/dialects/insert-tests.js
+++ b/test/dialects/insert-tests.js
@@ -675,3 +675,104 @@ Harness.test({
     string: 'INSERT INTO "arraytest" ("id", "numbers") VALUES (1, (\'one\', \'two\', \'three\'))'
   }
 });
+
+Harness.test({
+  query: post.insert(post.userId).select(user.id).from(user),
+  pg: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"'
+  },
+  mysql: {
+    text  : 'INSERT INTO `post` (`userId`) SELECT `user`.`id` FROM `user`',
+    string: 'INSERT INTO `post` (`userId`) SELECT `user`.`id` FROM `user`'
+  },
+  mssql: {
+    text  : 'INSERT INTO [post] ([userId]) SELECT [user].[id] FROM [user]',
+    string: 'INSERT INTO [post] ([userId]) SELECT [user].[id] FROM [user]'
+  },
+  oracle: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"'
+  },
+  params: []
+});
+
+Harness.test({
+  query: post.insert(post.userId).add(user.select(user.id)),
+  pg: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"'
+  },
+  mysql: {
+    text  : 'INSERT INTO `post` (`userId`) SELECT `user`.`id` FROM `user`',
+    string: 'INSERT INTO `post` (`userId`) SELECT `user`.`id` FROM `user`'
+  },
+  mssql: {
+    text  : 'INSERT INTO [post] ([userId]) SELECT [user].[id] FROM [user]',
+    string: 'INSERT INTO [post] ([userId]) SELECT [user].[id] FROM [user]'
+  },
+  oracle: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"'
+  },
+  params: []
+});
+
+Harness.test({
+  query: post.insert(post.userId).add(user.select(user.id).from(user)),
+  pg: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"'
+  },
+  mysql: {
+    text  : 'INSERT INTO `post` (`userId`) SELECT `user`.`id` FROM `user`',
+    string: 'INSERT INTO `post` (`userId`) SELECT `user`.`id` FROM `user`'
+  },
+  mssql: {
+    text  : 'INSERT INTO [post] ([userId]) SELECT [user].[id] FROM [user]',
+    string: 'INSERT INTO [post] ([userId]) SELECT [user].[id] FROM [user]'
+  },
+  oracle: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user"'
+  },
+  params: []
+});
+
+Harness.test({
+  query: post.insert(post.userId).add(user.select(user.id).order(user.id)),
+  pg: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" ORDER BY "user"."id"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" ORDER BY "user"."id"'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" ORDER BY "user"."id"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" ORDER BY "user"."id"'
+  },
+  mysql: {
+    text  : 'INSERT INTO `post` (`userId`) SELECT `user`.`id` FROM `user` ORDER BY `user`.`id`',
+    string: 'INSERT INTO `post` (`userId`) SELECT `user`.`id` FROM `user` ORDER BY `user`.`id`'
+  },
+  mssql: {
+    text  : 'INSERT INTO [post] ([userId]) SELECT [user].[id] FROM [user] ORDER BY [user].[id]',
+    string: 'INSERT INTO [post] ([userId]) SELECT [user].[id] FROM [user] ORDER BY [user].[id]'
+  },
+  oracle: {
+    text  : 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" ORDER BY "user"."id"',
+    string: 'INSERT INTO "post" ("userId") SELECT "user"."id" FROM "user" ORDER BY "user"."id"'
+  },
+  params: []
+});
+


### PR DESCRIPTION
Before this pull request, this code
```javascript
var query=post.insert(post.id)
var select=user.select(user.id)
query.add(select)
```
would generate (properly quoted)
```sql
INSERT INTO post (id) (SELECT user.id FROM user)
```
Notice the parentheses around the `SELECT` clause. In many cases, this isn't a problem, but in Microsoft SQL server, when you try to add an `ORDER BY` clause onto your select, it is a syntax error  when there are parentheses around the `SELECT` statement.

This pull request makes the above query generate:
```sql
INSERT INTO post (id) SELECT user.id FROM user
```
which is exactly what is generated when you write the query like:
```javascript
var query=post.insert(post.id).select(user.id).from(user)
```
So it actually generates more consistent SQL regardless of the way that the query was constructed.