### PR TITLE
Setting default values

### DIFF
--- a/lib/column.js
+++ b/lib/column.js
@@ -20,6 +20,7 @@ var Column = function(config) {
     direction : new TextNode('DESC')
   });
   this.dataType = config.dataType;
+  this.defaultValue = config.defaultValue;
 };
 
 // mix in value expression

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -809,6 +809,9 @@ Postgres.prototype.visitColumn = function(columnNode) {
       if (!columnNode.primaryKey && columnNode.unique) {
         txt.push(' UNIQUE');
       }
+      if (columnNode.defaultValue !== undefined) {
+        txt.push(' DEFAULT ' + this._getParameterValue(columnNode.defaultValue));
+      }
     }
 
     if (!!columnNode.references) {

--- a/lib/node/column.js
+++ b/lib/node/column.js
@@ -18,6 +18,7 @@ module.exports = Node.define({
     this.distinct = config.distinct;
     this.primaryKey = config.primaryKey;
     this.notNull = config.notNull;
+    this.defaultValue = config.defaultValue;
     this.references = config.references;
     // If subfieldContainer is present, this is a subfield and subfieldContainer
     // is the parent Column

--- a/test/dialects/create-table-tests.js
+++ b/test/dialects/create-table-tests.js
@@ -250,6 +250,39 @@ Harness.test({
 
 Harness.test({
   query: Table.define({
+    name: 'user',
+    columns: [{
+      name: 'id',
+      dataType: 'int',
+      primaryKey: true,
+      notNull: true
+    }, {
+      name: 'posts',
+      dataType: 'int',
+      notNull: true,
+      defaultValue: 0
+    }]
+  }).create(),
+  pg: {
+    text  : 'CREATE TABLE "user" ("id" int PRIMARY KEY, "posts" int NOT NULL DEFAULT 0)',
+    string: 'CREATE TABLE "user" ("id" int PRIMARY KEY, "posts" int NOT NULL DEFAULT 0)'
+  },
+  sqlite: {
+    text  : 'CREATE TABLE "user" ("id" int PRIMARY KEY, "posts" int NOT NULL DEFAULT 0)',
+    string: 'CREATE TABLE "user" ("id" int PRIMARY KEY, "posts" int NOT NULL DEFAULT 0)'
+  },
+  mysql: {
+    text  : 'CREATE TABLE `user` (`id` int PRIMARY KEY, `posts` int NOT NULL DEFAULT 0)',
+    string: 'CREATE TABLE `user` (`id` int PRIMARY KEY, `posts` int NOT NULL DEFAULT 0)'
+  },
+  oracle: {
+    text  : 'CREATE TABLE "user" ("id" int PRIMARY KEY, "posts" int NOT NULL DEFAULT 0)',
+    string: 'CREATE TABLE "user" ("id" int PRIMARY KEY, "posts" int NOT NULL DEFAULT 0)'
+  }
+});
+
+Harness.test({
+  query: Table.define({
     name: 'post',
     columns: [{
       name: 'userId',


### PR DESCRIPTION
I might have overlooked something blindingly obvious, but I couldn't find any way of setting the default value of a column when creating a table.  This pull request adds a defaultValue parameter which does just that.

Synopsis:

```
var table = sql.define({
  name: 'test',
  columns:
  [
    {
      name: 'id',
      dataType: 'int',
      primaryKey: true
    },
    {
      name: 'favourite_vegetable',
      dataType: 'text',
      defaultValue: 'cauliflower'
    }
  ]
});
```

Produces the table creation query

```
CREATE TABLE "test" ("id" int PRIMARY KEY, "favourite_vegetable" text DEFAULT 'cauliflower')
```
