### PR TITLE
Add table level foreign keys

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -153,6 +153,7 @@ Postgres.prototype.visit = function(node) {
     case 'FOR SHARE'       : return this.visitForShare();
     case 'TABLE'           : return this.visitTable(node);
     case 'COLUMN'          : return this.visitColumn(node);
+    case 'FOREIGN KEY'     : return this.visitForeignKey(node);
     case 'JOIN'            : return this.visitJoin(node);
     case 'LITERAL'         : return this.visitLiteral(node);
     case 'TEXT'            : return node.text;
@@ -296,6 +297,7 @@ Postgres.prototype.visitCreate = function(create) {
   // don't auto-generate from clause
   var table = this._queryNode.table;
   var col_nodes = table.columns.map(function(col) { return col.toNode(); });
+  var foreign_key_nodes = table.foreignKeys;
 
    var result = ['CREATE TABLE'];
   if (create.options.isTemporary) result=['CREATE TEMPORARY TABLE'];
@@ -312,6 +314,9 @@ Postgres.prototype.visitCreate = function(create) {
       return this.quote(node.name);
     }.bind(this)).join(', ');
     colspec += ')';
+  }
+  if(foreign_key_nodes.length > 0) {
+    colspec += ', ' + foreign_key_nodes.map(this.visit.bind(this)).join(', ');
   }
   colspec += ')';
   result.push(colspec);
@@ -845,6 +850,46 @@ Postgres.prototype.visitColumn = function(columnNode) {
           txt.push(constraint);
         }
       }
+    }
+  }
+  return [txt.join('')];
+};
+
+Postgres.prototype.visitForeignKey = function(foreignKeyNode)
+{
+  var txt = [];
+  if(this._visitingCreate) {
+    assert(foreignKeyNode.table, 'Foreign table missing for table reference');
+    assert(foreignKeyNode.columns, 'Columns missing for table reference');
+    assert(foreignKeyNode.refColumns, 'Foreign columns missing for table reference');
+    assert.equal(foreignKeyNode.columns.length, foreignKeyNode.refColumns.length, 'Number of local columns and foreign columns differ in table reference');
+    txt.push('FOREIGN KEY ( ');
+    for(var i = 0; i < foreignKeyNode.columns.length; i++) {
+      if(i>0) {
+        txt.push(', ');
+      }
+      txt.push(this.quote(foreignKeyNode.columns[i]));
+    }
+    txt.push(' ) REFERENCES ');
+    if(foreignKeyNode.schema !== undefined) {
+      txt.push(this.quote(foreignKeyNode.schema) + '.');
+    }
+    txt.push(this.quote(foreignKeyNode.table) + ' ( ');
+    for(i = 0; i < foreignKeyNode.refColumns.length; i++) {
+      if(i>0) {
+        txt.push(', ');
+      }
+      txt.push(this.quote(foreignKeyNode.refColumns[i]));
+    }
+    txt.push(' )');
+    if(foreignKeyNode.onDelete) {
+      foreignKeyNode.onDelete = foreignKeyNode.onDelete.toUpperCase();
+      if(foreignKeyNode.onDelete === 'CASCADE' || foreignKeyNode.onDelete === 'RESTRICT') {
+        txt.push(' ON DELETE ' + foreignKeyNode.onDelete);
+      }
+    }
+    if(foreignKeyNode.constraint) {
+      txt.push(' ' + foreignKeyNode.constraint.toUpperCase());
     }
   }
   return [txt.join('')];

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -861,8 +861,9 @@ Postgres.prototype.visitForeignKey = function(foreignKeyNode)
   if(this._visitingCreate) {
     assert(foreignKeyNode.table, 'Foreign table missing for table reference');
     assert(foreignKeyNode.columns, 'Columns missing for table reference');
-    assert(foreignKeyNode.refColumns, 'Foreign columns missing for table reference');
-    assert.equal(foreignKeyNode.columns.length, foreignKeyNode.refColumns.length, 'Number of local columns and foreign columns differ in table reference');
+    if(foreignKeyNode.refColumns !== undefined) {
+      assert.equal(foreignKeyNode.columns.length, foreignKeyNode.refColumns.length, 'Number of local columns and foreign columns differ in table reference');
+    }
     txt.push('FOREIGN KEY ( ');
     for(var i = 0; i < foreignKeyNode.columns.length; i++) {
       if(i>0) {
@@ -874,14 +875,17 @@ Postgres.prototype.visitForeignKey = function(foreignKeyNode)
     if(foreignKeyNode.schema !== undefined) {
       txt.push(this.quote(foreignKeyNode.schema) + '.');
     }
-    txt.push(this.quote(foreignKeyNode.table) + ' ( ');
-    for(i = 0; i < foreignKeyNode.refColumns.length; i++) {
-      if(i>0) {
-        txt.push(', ');
+    txt.push(this.quote(foreignKeyNode.table));
+    if(foreignKeyNode.refColumns !== undefined) {
+      txt.push(' ( ');
+      for(i = 0; i < foreignKeyNode.refColumns.length; i++) {
+        if(i>0) {
+          txt.push(', ');
+        }
+        txt.push(this.quote(foreignKeyNode.refColumns[i]));
       }
-      txt.push(this.quote(foreignKeyNode.refColumns[i]));
+      txt.push(' )');
     }
-    txt.push(' )');
     if(foreignKeyNode.onDelete) {
       foreignKeyNode.onDelete = foreignKeyNode.onDelete.toUpperCase();
       if(foreignKeyNode.onDelete === 'CASCADE' || foreignKeyNode.onDelete === 'RESTRICT') {

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -844,6 +844,11 @@ Postgres.prototype.visitColumn = function(columnNode) {
         if (onDelete === 'CASCADE' || onDelete === 'RESTRICT') {
           txt.push(' ON DELETE ' + onDelete);
         }
+        var onUpdate = columnNode.references.onUpdate;
+        if (onUpdate) onUpdate = onUpdate.toUpperCase();
+        if (onUpdate === 'CASCADE' || onUpdate === 'RESTRICT') {
+          txt.push(' ON UPDATE ' + onUpdate);
+        }
         var constraint = columnNode.references.constraint;
         if (constraint) {
           constraint = ' ' + constraint.toUpperCase();
@@ -893,6 +898,12 @@ Postgres.prototype.visitForeignKey = function(foreignKeyNode)
       foreignKeyNode.onDelete = foreignKeyNode.onDelete.toUpperCase();
       if(foreignKeyNode.onDelete === 'CASCADE' || foreignKeyNode.onDelete === 'RESTRICT') {
         txt.push(' ON DELETE ' + foreignKeyNode.onDelete);
+      }
+    }
+    if(foreignKeyNode.onUpdate) {
+      foreignKeyNode.onUpdate = foreignKeyNode.onUpdate.toUpperCase();
+      if(foreignKeyNode.onUpdate === 'CASCADE' || foreignKeyNode.onUpdate === 'RESTRICT') {
+        txt.push(' ON UPDATE ' + foreignKeyNode.onUpdate);
       }
     }
     if(foreignKeyNode.constraint) {

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -864,6 +864,9 @@ Postgres.prototype.visitForeignKey = function(foreignKeyNode)
     if(foreignKeyNode.refColumns !== undefined) {
       assert.equal(foreignKeyNode.columns.length, foreignKeyNode.refColumns.length, 'Number of local columns and foreign columns differ in table reference');
     }
+    if(foreignKeyNode.name !== undefined) {
+      txt.push('CONSTRAINT ' + this.quote(foreignKeyNode.name) + ' ');
+    }
     txt.push('FOREIGN KEY ( ');
     for(var i = 0; i < foreignKeyNode.columns.length; i++) {
       if(i>0) {

--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -841,12 +841,12 @@ Postgres.prototype.visitColumn = function(columnNode) {
 
         var onDelete = columnNode.references.onDelete;
         if (onDelete) onDelete = onDelete.toUpperCase();
-        if (onDelete === 'CASCADE' || onDelete === 'RESTRICT') {
+        if (onDelete === 'CASCADE' || onDelete === 'RESTRICT' || onDelete === 'SET NULL' || onDelete === 'SET DEFAULT' || onDelete === 'NO ACTION') {
           txt.push(' ON DELETE ' + onDelete);
         }
         var onUpdate = columnNode.references.onUpdate;
         if (onUpdate) onUpdate = onUpdate.toUpperCase();
-        if (onUpdate === 'CASCADE' || onUpdate === 'RESTRICT') {
+        if (onUpdate === 'CASCADE' || onUpdate === 'RESTRICT' || onUpdate === 'SET NULL' || onUpdate === 'SET DEFAULT' || onUpdate === 'NO ACTION') {
           txt.push(' ON UPDATE ' + onUpdate);
         }
         var constraint = columnNode.references.constraint;
@@ -894,16 +894,18 @@ Postgres.prototype.visitForeignKey = function(foreignKeyNode)
       }
       txt.push(' )');
     }
-    if(foreignKeyNode.onDelete) {
-      foreignKeyNode.onDelete = foreignKeyNode.onDelete.toUpperCase();
-      if(foreignKeyNode.onDelete === 'CASCADE' || foreignKeyNode.onDelete === 'RESTRICT') {
-        txt.push(' ON DELETE ' + foreignKeyNode.onDelete);
+    var onDelete = foreignKeyNode.onDelete;
+    if(onDelete) {
+      onDelete = onDelete.toUpperCase();
+      if(onDelete === 'CASCADE' || onDelete === 'RESTRICT' || onDelete === 'SET NULL' || onDelete === 'SET DEFAULT' || onDelete === 'NO ACTION') {
+        txt.push(' ON DELETE ' + onDelete);
       }
     }
-    if(foreignKeyNode.onUpdate) {
-      foreignKeyNode.onUpdate = foreignKeyNode.onUpdate.toUpperCase();
-      if(foreignKeyNode.onUpdate === 'CASCADE' || foreignKeyNode.onUpdate === 'RESTRICT') {
-        txt.push(' ON UPDATE ' + foreignKeyNode.onUpdate);
+    var onUpdate = foreignKeyNode.onUpdate;
+    if(onUpdate) {
+      onUpdate = onUpdate.toUpperCase();
+      if(onUpdate === 'CASCADE' || onUpdate === 'RESTRICT' || onUpdate === 'SET NULL' || onUpdate === 'SET DEFAULT' || onUpdate === 'NO ACTION') {
+        txt.push(' ON UPDATE ' + onUpdate);
       }
     }
     if(foreignKeyNode.constraint) {

--- a/lib/node/foreignKey.js
+++ b/lib/node/foreignKey.js
@@ -6,6 +6,7 @@ module.exports = Node.define({
   type: 'FOREIGN KEY',
   constructor: function(config) {
     Node.call(this);
+    this.name = config.name;
     this.columns = config.columns;
     this.schema = config.schema;
     this.table = config.table;

--- a/lib/node/foreignKey.js
+++ b/lib/node/foreignKey.js
@@ -11,6 +11,7 @@ module.exports = Node.define({
     this.schema = config.schema;
     this.table = config.table;
     this.refColumns = config.refColumns;
+    this.onUpdate = config.onUpdate;
     this.onDelete = config.onDelete;
     this.constraint = config.constraint;
   }

--- a/lib/node/foreignKey.js
+++ b/lib/node/foreignKey.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var Node = require(__dirname);
+
+module.exports = Node.define({
+  type: 'FOREIGN KEY',
+  constructor: function(config) {
+    Node.call(this);
+    this.columns = config.columns;
+    this.schema = config.schema;
+    this.table = config.table;
+    this.refColumns = config.refColumns;
+    this.onDelete = config.onDelete;
+    this.constraint = config.constraint;
+  }
+});
+

--- a/lib/table.js
+++ b/lib/table.js
@@ -9,6 +9,7 @@ var TableNode = require(__dirname + '/node/table');
 var JoinNode = require(__dirname + '/node/join');
 var LiteralNode = require(__dirname + '/node/literal');
 var Joiner = require(__dirname + '/joiner');
+var ForeignKeyNode = require(__dirname + '/node/foreignKey');
 
 var Table = function(config) {
   this._schema = config.schema;
@@ -18,6 +19,7 @@ var Table = function(config) {
   this.isTemporary=!!config.isTemporary;
   this.snakeToCamel = !!config.snakeToCamel;
   this.columns = [];
+  this.foreignKeys = [];
   this.table = this;
   if (!config.sql) {
     config.sql = require('./index');
@@ -45,6 +47,16 @@ Table.define = function(config) {
   for (var i = 0; i < config.columns.length; i++) {
     table.addColumn(config.columns[i]);
   }
+
+  if(config.foreignKeys !== undefined) {
+    if(util.isArray(config.foreignKeys)) {
+      for(i = 0; i < config.foreignKeys.length; i++) {
+        table.foreignKeys.push(new ForeignKeyNode(config.foreignKeys[i]));
+      }
+    } else {
+      table.foreignKeys.push(new ForeignKeyNode(config.foreignKeys));
+    }
+  }
   return table;
 };
 
@@ -55,7 +67,8 @@ Table.prototype.clone = function(config) {
     sql: this.sql,
     columnWhiteList: !!this.columnWhiteList,
     snakeToCamel: !!this.snakeToCamel,
-    columns: this.columns
+    columns: this.columns,
+    foreignKeys: this.foreignKeys
   }, config || {}));
 };
 

--- a/test/dialects/create-table-tests.js
+++ b/test/dialects/create-table-tests.js
@@ -701,6 +701,7 @@ Harness.test({
       table: 'users',
       columns: [ 'blog_id', 'user_id' ]
     }, {
+      name: 'posts_idx',
       table: 'posts',
       columns: [ 'blog_id', 'post_id' ],
       refColumns: [ 'blog_id', 'id' ],
@@ -708,16 +709,16 @@ Harness.test({
     }]
   }).create(),
   pg: {
-    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
-    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
+    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
+    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
   },
   sqlite: {
-    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
-    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
+    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
+    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
   },
   mysql: {
-    text  : 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)',
-    string: 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)'
+    text  : 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, CONSTRAINT `posts_idx` FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)',
+    string: 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, CONSTRAINT `posts_idx` FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)'
   },
   params: []
 });

--- a/test/dialects/create-table-tests.js
+++ b/test/dialects/create-table-tests.js
@@ -644,3 +644,81 @@ Harness.test({
   },
   params: []
 });
+
+Harness.test({
+  query: Table.define({
+    name: 'post',
+    columns: [{
+      name: 'id',
+      dataType: 'int',
+      primaryKey: true
+    }, {
+      name: 'blog_id',
+      dataType: 'int'
+    }, {
+      name: 'user_id',
+      dataType: 'int'
+    }],
+    foreignKeys: {
+      table: 'users',
+      columns: [ 'blog_id', 'user_id' ],
+      refColumns: [ 'id', 'user_id' ]
+    }
+  }).create(),
+  pg: {
+    text  : 'CREATE TABLE "post" ("id" int PRIMARY KEY, "blog_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "id", "user_id" ))',
+    string: 'CREATE TABLE "post" ("id" int PRIMARY KEY, "blog_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "id", "user_id" ))'
+  },
+  sqlite: {
+    text  : 'CREATE TABLE "post" ("id" int PRIMARY KEY, "blog_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "id", "user_id" ))',
+    string: 'CREATE TABLE "post" ("id" int PRIMARY KEY, "blog_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "id", "user_id" ))'
+  },
+  mysql: {
+    text  : 'CREATE TABLE `post` (`id` int PRIMARY KEY, `blog_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users` ( `id`, `user_id` ))',
+    string: 'CREATE TABLE `post` (`id` int PRIMARY KEY, `blog_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users` ( `id`, `user_id` ))'
+  },
+  params: []
+});
+
+Harness.test({
+  query: Table.define({
+    name: 'replies',
+    columns: [{
+      name: 'id',
+      dataType: 'int',
+      primaryKey: true
+    }, {
+      name: 'blog_id',
+      dataType: 'int'
+    }, {
+      name: 'post_id',
+      dataType: 'int'
+    }, {
+      name: 'user_id',
+      dataType: 'int'
+    }],
+    foreignKeys: [{
+      table: 'users',
+      columns: [ 'blog_id', 'user_id' ],
+      refColumns: [ 'blog_id', 'id' ]
+    }, {
+      table: 'posts',
+      columns: [ 'blog_id', 'post_id' ],
+      refColumns: [ 'blog_id', 'id' ],
+      onDelete: 'cascade'
+    }]
+  }).create(),
+  pg: {
+    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "blog_id", "id" ), FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
+    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "blog_id", "id" ), FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
+  },
+  sqlite: {
+    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "blog_id", "id" ), FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
+    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "blog_id", "id" ), FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
+  },
+  mysql: {
+    text  : 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users` ( `blog_id`, `id` ), FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)',
+    string: 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users` ( `blog_id`, `id` ), FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)'
+  },
+  params: []
+});

--- a/test/dialects/create-table-tests.js
+++ b/test/dialects/create-table-tests.js
@@ -258,25 +258,25 @@ Harness.test({
         table: 'user',
         column: 'id',
         onDelete: 'restrict',
-        onUpdate: 'cascade'
+        onUpdate: 'set null'
       }
     }]
   }).create(),
   pg: {
-    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)',
-    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)'
+    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE SET NULL)',
+    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE SET NULL)'
   },
   sqlite: {
-    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)',
-    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)'
+    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE SET NULL)',
+    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE SET NULL)'
   },
   mysql: {
-    text  : 'CREATE TABLE `post` (`userId` int REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE)',
-    string: 'CREATE TABLE `post` (`userId` int REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE)'
+    text  : 'CREATE TABLE `post` (`userId` int REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE SET NULL)',
+    string: 'CREATE TABLE `post` (`userId` int REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE SET NULL)'
   },
   oracle: {
-    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)',
-    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)'
+    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE SET NULL)',
+    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE SET NULL)'
   },
   params: []
 });
@@ -701,27 +701,28 @@ Harness.test({
     }],
     foreignKeys: [{
       table: 'users',
-      columns: [ 'blog_id', 'user_id' ]
+      columns: [ 'blog_id', 'user_id' ],
+      onDelete: 'no action'
     }, {
       name: 'posts_idx',
       table: 'posts',
       columns: [ 'blog_id', 'post_id' ],
       refColumns: [ 'blog_id', 'id' ],
       onDelete: 'cascade',
-      onUpdate: 'cascade'
+      onUpdate: 'set default'
     }]
   }).create(),
   pg: {
-    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE CASCADE)',
-    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE CASCADE)'
+    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ON DELETE NO ACTION, CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE SET DEFAULT)',
+    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ON DELETE NO ACTION, CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE SET DEFAULT)'
   },
   sqlite: {
-    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE CASCADE)',
-    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE CASCADE)'
+    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ON DELETE NO ACTION, CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE SET DEFAULT)',
+    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ON DELETE NO ACTION, CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE SET DEFAULT)'
   },
   mysql: {
-    text  : 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, CONSTRAINT `posts_idx` FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE ON UPDATE CASCADE)',
-    string: 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, CONSTRAINT `posts_idx` FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE ON UPDATE CASCADE)'
+    text  : 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users` ON DELETE NO ACTION, CONSTRAINT `posts_idx` FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE ON UPDATE SET DEFAULT)',
+    string: 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users` ON DELETE NO ACTION, CONSTRAINT `posts_idx` FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE ON UPDATE SET DEFAULT)'
   },
   params: []
 });

--- a/test/dialects/create-table-tests.js
+++ b/test/dialects/create-table-tests.js
@@ -699,8 +699,7 @@ Harness.test({
     }],
     foreignKeys: [{
       table: 'users',
-      columns: [ 'blog_id', 'user_id' ],
-      refColumns: [ 'blog_id', 'id' ]
+      columns: [ 'blog_id', 'user_id' ]
     }, {
       table: 'posts',
       columns: [ 'blog_id', 'post_id' ],
@@ -709,16 +708,16 @@ Harness.test({
     }]
   }).create(),
   pg: {
-    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "blog_id", "id" ), FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
-    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "blog_id", "id" ), FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
+    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
+    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
   },
   sqlite: {
-    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "blog_id", "id" ), FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
-    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users" ( "blog_id", "id" ), FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
+    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
+    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
   },
   mysql: {
-    text  : 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users` ( `blog_id`, `id` ), FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)',
-    string: 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users` ( `blog_id`, `id` ), FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)'
+    text  : 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)',
+    string: 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)'
   },
   params: []
 });

--- a/test/dialects/create-table-tests.js
+++ b/test/dialects/create-table-tests.js
@@ -256,25 +256,27 @@ Harness.test({
       dataType: 'int',
       references: {
         table: 'user',
-        column: 'id'
+        column: 'id',
+        onDelete: 'restrict',
+        onUpdate: 'cascade'
       }
     }]
   }).create(),
   pg: {
-    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id"))',
-    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id"))'
+    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)',
+    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)'
   },
   sqlite: {
-    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id"))',
-    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id"))'
+    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)',
+    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)'
   },
   mysql: {
-    text  : 'CREATE TABLE `post` (`userId` int REFERENCES `user`(`id`))',
-    string: 'CREATE TABLE `post` (`userId` int REFERENCES `user`(`id`))'
+    text  : 'CREATE TABLE `post` (`userId` int REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE)',
+    string: 'CREATE TABLE `post` (`userId` int REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE)'
   },
   oracle: {
-    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id"))',
-    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id"))'
+    text  : 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)',
+    string: 'CREATE TABLE "post" ("userId" int REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE)'
   },
   params: []
 });
@@ -705,20 +707,21 @@ Harness.test({
       table: 'posts',
       columns: [ 'blog_id', 'post_id' ],
       refColumns: [ 'blog_id', 'id' ],
-      onDelete: 'cascade'
+      onDelete: 'cascade',
+      onUpdate: 'cascade'
     }]
   }).create(),
   pg: {
-    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
-    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
+    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE CASCADE)',
+    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE CASCADE)'
   },
   sqlite: {
-    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)',
-    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE)'
+    text  : 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE CASCADE)',
+    string: 'CREATE TABLE "replies" ("id" int PRIMARY KEY, "blog_id" int, "post_id" int, "user_id" int, FOREIGN KEY ( "blog_id", "user_id" ) REFERENCES "users", CONSTRAINT "posts_idx" FOREIGN KEY ( "blog_id", "post_id" ) REFERENCES "posts" ( "blog_id", "id" ) ON DELETE CASCADE ON UPDATE CASCADE)'
   },
   mysql: {
-    text  : 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, CONSTRAINT `posts_idx` FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)',
-    string: 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, CONSTRAINT `posts_idx` FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE)'
+    text  : 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, CONSTRAINT `posts_idx` FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE ON UPDATE CASCADE)',
+    string: 'CREATE TABLE `replies` (`id` int PRIMARY KEY, `blog_id` int, `post_id` int, `user_id` int, FOREIGN KEY ( `blog_id`, `user_id` ) REFERENCES `users`, CONSTRAINT `posts_idx` FOREIGN KEY ( `blog_id`, `post_id` ) REFERENCES `posts` ( `blog_id`, `id` ) ON DELETE CASCADE ON UPDATE CASCADE)'
   },
   params: []
 });


### PR DESCRIPTION
Allows foreign keys which use muliple columns. This code:

```
var table1 = sql.define({
  name: 'table1',
  columns: [
    {name: 'id', dataType: 'int'},
    {name: 'ref1', dataType: 'text'},
    {name: 'ref2', dataType: 'text'},
    {name: 'text', dataType: 'text'}
  ]
});

var table2 = sql.define({
  name: 'table2',
  columns: [
    {name: 'id', dataType: 'int'},
    {name: 'ref', dataType: 'text'},
    {name: 'data', dataType: 'text'}
  ],
  foreignKeys: {
    table: 'table1',
    columns: ['id', 'ref'],
    refColumns: ['id', 'ref1'],
    onDelete: 'cascade'
  }
});

console.log(table1.create().toQuery().text);
console.log(table2.create().toQuery().text);
```

produces this output:

```
CREATE TABLE "table1" ("id" int, "ref1" text, "ref2" text, "text" text)
CREATE TABLE "table2" ("id" int, "ref" text, "data" text, FOREIGN KEY ( "id", "ref" ) REFERENCES "table1" ( "id", "ref1" ) ON DELETE CASCADE)
```

Naturally you can have an array of foreign keys if you want more than one.