### PR TITLE
Simplify lib/functions.

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,37 +1,17 @@
 'use strict';
-var _ = require('lodash');
 var sliced = require('sliced');
 var FunctionCall = require(__dirname + '/node/functionCall');
 
-// create a function that creates a function call of the specific name, using the specified sql instance
-var getFunctionCallCreator = function(name) {
-  return function() {
-    // turn array-like arguments object into a true array
-    return new FunctionCall(name, sliced(arguments));
-  };
-};
-
-// creates a hash of functions for a sql instance
-var getFunctions = function(functionNames) {
-  var functions = _.reduce(functionNames, function(reducer, name) {
-    reducer[name] = getFunctionCallCreator(name);
-    return reducer;
-  }, {});
-  return functions;
-};
-
-// aggregate functions available to all databases
-var aggregateFunctions = [
+var standardFunctionNames = [
+  // aggregate functions available to all databases
   'AVG',
   'COUNT',
   'DISTINCT',
   'MAX',
   'MIN',
-  'SUM'
-];
+  'SUM',
 
-// common scalar functions available to most databases
-var scalarFunctions = [
+  // common scalar functions available to most databases
   'ABS',
   'COALESCE',
   'LEFT',
@@ -44,20 +24,26 @@ var scalarFunctions = [
   'RTRIM',
   'SUBSTR',
   'TRIM',
-  'UPPER'
+  'UPPER',
+
+  // hstore function available to Postgres
+  'HSTORE',
+
+  // text search functions available to Postgres
+  'TS_RANK',
+  'TS_RANK_CD',
+  'PLAINTO_TSQUERY',
+  'TO_TSQUERY',
+  'TO_TSVECTOR',
+  'SETWEIGHT'
 ];
 
-// hstore function available to Postgres
-var hstoreFunction = 'HSTORE';
-
-//text search functions available to Postgres
-var textsearchFunctions = ['TS_RANK','TS_RANK_CD', 'PLAINTO_TSQUERY', 'TO_TSQUERY', 'TO_TSVECTOR', 'SETWEIGHT'];
-
-var standardFunctionNames = aggregateFunctions.concat(scalarFunctions).concat(hstoreFunction).concat(textsearchFunctions);
-
 // creates a hash of standard functions for a sql instance
-var getStandardFunctions = function() {
-  return getFunctions(standardFunctionNames);
+module.exports.getStandardFunctions = function () {
+  return standardFunctionNames.reduce(function (functions, name) {
+    functions[name] = function () {
+      return new FunctionCall(name, sliced(arguments));
+    };
+    return functions;
+  }, {});
 };
-
-module.exports.getStandardFunctions = getStandardFunctions;


### PR DESCRIPTION
Since the various arrays of function calls are never exposed outside of this file we can go ahead and combine them, making the calls to #concat unnecessary. Yea?
