### PR TITLE
Fix sqlite date functions for epoch

### DIFF
--- a/lib/dialect/sqlite.js
+++ b/lib/dialect/sqlite.js
@@ -81,7 +81,13 @@ Sqlite.prototype.visitFunctionCall = function (functionCall) {
         format = "'%H'";
         break;
     }
-    var txt = 'strftime(' + format + ', ' + (nodes[0] + '') + ')';
+    var col = (nodes[0] + '');
+    if (_this.config.dateTimeMillis) {
+      // Convert to a datetime before running the strftime function
+      // Sqlite unix epoch is in seconds, but javascript is milliseconds.
+      col = 'datetime(' + col + '/1000, "unixepoch")';
+    }
+    var txt = 'strftime(' + format + ', ' + col + ')';
     return txt;
   }
 

--- a/test/dialects/date-tests.js
+++ b/test/dialects/date-tests.js
@@ -36,8 +36,11 @@ Harness.test({
     string: 'SELECT EXTRACT(MONTH FROM "customer"."metadata") FROM "customer"'
   },
   sqlite: {
-    text  : 'SELECT strftime(\'%m\', "customer"."metadata") FROM "customer"',
-    string: 'SELECT strftime(\'%m\', "customer"."metadata") FROM "customer"'
+    text: 'SELECT strftime(\'%m\', datetime("customer"."metadata"/1000, "unixepoch")) FROM "customer"',
+    string: 'SELECT strftime(\'%m\', datetime("customer"."metadata"/1000, "unixepoch")) FROM "customer"',
+    config: {
+      dateTimeMillis: true
+    }
   },
   mysql: {
     text  : 'SELECT MONTH(`customer`.`metadata`) FROM `customer`',
@@ -86,8 +89,11 @@ Harness.test({
     string: 'SELECT EXTRACT(HOUR FROM "customer"."metadata") FROM "customer"'
   },
   sqlite: {
-    text  : 'SELECT strftime(\'%H\', "customer"."metadata") FROM "customer"',
-    string: 'SELECT strftime(\'%H\', "customer"."metadata") FROM "customer"'
+    text: 'SELECT strftime(\'%H\', datetime("customer"."metadata"/1000, "unixepoch")) FROM "customer"',
+    string: 'SELECT strftime(\'%H\', datetime("customer"."metadata"/1000, "unixepoch")) FROM "customer"',
+    config: {
+      dateTimeMillis: true
+    }
   },
   mysql: {
     text  : 'SELECT HOUR(`customer`.`metadata`) FROM `customer`',


### PR DESCRIPTION
Via configuration you can set SQLite to use epoch timestamps or ISO formatted dates.  The original implementation only worked for ISO formatted dates.  This PR fixes that.