### PR TITLE
Fix Table.hasColumn for columns with custom property names

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -126,13 +126,10 @@ Table.prototype.addColumn = function(col, options) {
 };
 
 Table.prototype.hasColumn = function(col) {
-  col = this.createColumn(col);
-
-  var cols = this.columns.filter(function(column) {
-    return column.property === col.property || column.name === col.name;
+  var columnName = col instanceof Column ? col.name : col;
+  return this.columns.some(function(column) {
+    return column.property === columnName || column.name === columnName;
   });
-
-  return cols.length > 0;
 };
 
 Table.prototype.getColumn =

--- a/test/table-tests.js
+++ b/test/table-tests.js
@@ -167,6 +167,19 @@ test('hasColumn', function() {
   assert.equal(table.hasColumn('baz'), true);
 });
 
+test('hasColumn with user-defined column property', function() {
+  var table = Table.define({
+    name: 'blah',
+    columns: [{
+        name: 'id',
+        property: 'theId'
+    }, {name: 'foo'}]
+  });
+
+  assert.equal(table.hasColumn('id'), true);
+  assert.equal(table.hasColumn('theId'), true);
+});
+
 test('the column "from" does not overwrite the from method', function() {
   var table = Table.define({ name: 'foo', columns: [] });
   table.addColumn('from');


### PR DESCRIPTION
There was a bug which caused Table.hasColumn to return false when passed a property name (defined via column.property) instead of a column name.

This now works and all tests pass:

``` javascript
test('hasColumn with user-defined column property', function() {
  var table = Table.define({
    name: 'blah',
    columns: [{
        name: 'id',
        property: 'theId'
    }, {name: 'foo'}]
  });

  assert.equal(table.hasColumn('id'), true);
  assert.equal(table.hasColumn('theId'), true);
});
```
