### PR TITLE
Use count(*) syntax for MySQL instead of count(`table`.*)

### DIFF
--- a/lib/dialect/mysql.js
+++ b/lib/dialect/mysql.js
@@ -126,5 +126,29 @@ Mysql.prototype.visitFunctionCall = function(functionCall) {
   return [txt];
 };
 
+Mysql.prototype.visitColumn = function(columnNode) {
+  var self = this;
+  var inSelectClause;
+
+  function isCountStarExpression(columnNode){
+    if (!columnNode.aggregator) return false;
+    if (columnNode.aggregator.toLowerCase()!='count') return false;
+    if (!columnNode.star) return false;
+    return true;
+  }
+
+  function _countStar(){
+    // Implement our own since count(table.*) is invalid in Mysql
+    var result='COUNT(*)';
+    if(inSelectClause && columnNode.alias) {
+      result += ' AS ' + self.quote(columnNode.alias);
+    }
+    return result;
+  }
+
+  inSelectClause = !this._selectOrDeleteEndIndex;
+  if(isCountStarExpression(columnNode)) return _countStar();
+  return Mysql.super_.prototype.visitColumn.call(this, columnNode);
+};
 
 module.exports = Mysql;

--- a/test/dialects/aggregate-tests.js
+++ b/test/dialects/aggregate-tests.js
@@ -16,8 +16,8 @@ Harness.test({
     string: 'SELECT COUNT("post".*) AS "post_count" FROM "post"'
   },
   mysql: {
-    text  : 'SELECT COUNT(`post`.*) AS `post_count` FROM `post`',
-    string: 'SELECT COUNT(`post`.*) AS `post_count` FROM `post`'
+    text  : 'SELECT COUNT(*) AS `post_count` FROM `post`',
+    string: 'SELECT COUNT(*) AS `post_count` FROM `post`'
   },
   mssql: {
     text  : 'SELECT COUNT(*) AS [post_count] FROM [post]',
@@ -41,8 +41,8 @@ Harness.test({
     string: 'SELECT COUNT("post".*) AS "post_count" FROM "post"'
   },
   msyql: {
-    text  : 'SELECT COUNT(`post`.*) AS `post_count` FROM `post`',
-    string: 'SELECT COUNT(`post`.*) AS `post_count` FROM `post`'
+    text  : 'SELECT COUNT(*) AS `post_count` FROM `post`',
+    string: 'SELECT COUNT(*) AS `post_count` FROM `post`'
   },
   mssql: {
     text  : 'SELECT COUNT(*) AS [post_count] FROM [post]',
@@ -66,8 +66,8 @@ Harness.test({
     string: 'SELECT COUNT("post".*) AS "post_amount" FROM "post"'
   },
   mysql: {
-    text  : 'SELECT COUNT(`post`.*) AS `post_amount` FROM `post`',
-    string: 'SELECT COUNT(`post`.*) AS `post_amount` FROM `post`'
+    text  : 'SELECT COUNT(*) AS `post_amount` FROM `post`',
+    string: 'SELECT COUNT(*) AS `post_amount` FROM `post`'
   },
   mssql: {
     text  : 'SELECT COUNT(*) AS [post_amount] FROM [post]',
@@ -166,8 +166,8 @@ Harness.test({
     string: 'SELECT COUNT("customer".*) AS "customer_count" FROM "customer"'
   },
   mysql: {
-    text  : 'SELECT COUNT(`customer`.*) AS `customer_count` FROM `customer`',
-    string: 'SELECT COUNT(`customer`.*) AS `customer_count` FROM `customer`'
+    text  : 'SELECT COUNT(*) AS `customer_count` FROM `customer`',
+    string: 'SELECT COUNT(*) AS `customer_count` FROM `customer`'
   },
   oracle: {
     text  : 'SELECT COUNT(*) "customer_count" FROM "customer"',


### PR DESCRIPTION
MySQL doesn't accept count(`table`.*) syntax.  Changed to count(*) by blagging code from MSSQL dialect.