### PR TITLE
Fix calling insert with an object that has a length property

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -208,7 +208,7 @@ Table.prototype.subQuery = function(alias) {
 
 Table.prototype.insert = function() {
   var query = new Query(this);
-  if(arguments[0].length === 0){
+  if(!arguments[0] || (util.isArray(arguments[0]) && arguments[0].length === 0)){
     query.select.call(query, this.star());
     query.where.apply(query,["1=2"]);
   } else {

--- a/test/dialects/insert-tests.js
+++ b/test/dialects/insert-tests.js
@@ -56,6 +56,31 @@ Harness.test({
 });
 
 Harness.test({
+  query: post.insert({length: 0}),
+  pg: {
+    text  : 'INSERT INTO "post" ("length") VALUES ($1)',
+    string: 'INSERT INTO "post" ("length") VALUES (0)'
+  },
+  sqlite: {
+    text  : 'INSERT INTO "post" ("length") VALUES ($1)',
+    string: 'INSERT INTO "post" ("length") VALUES (0)'
+  },
+  mysql: {
+    text  : 'INSERT INTO `post` (`length`) VALUES (?)',
+    string: 'INSERT INTO `post` (`length`) VALUES (0)'
+  },
+  mssql: {
+    text  : 'INSERT INTO [post] ([length]) VALUES (@1)',
+    string: 'INSERT INTO [post] ([length]) VALUES (0)'
+  },
+  oracle: {
+    text  : 'INSERT INTO "post" ("length") VALUES (:1)',
+    string: 'INSERT INTO "post" ("length") VALUES (0)'
+  },
+  params: [0]
+});
+
+Harness.test({
   query: post.insert({
     content: 'test',
     userId: 2

--- a/test/dialects/support.js
+++ b/test/dialects/support.js
@@ -76,7 +76,7 @@ module.exports = {
   definePostTable: function() {
     return Table.define({
       name: 'post',
-      columns: ['id', 'userId', 'content', 'tags']
+      columns: ['id', 'userId', 'content', 'tags', 'length']
     });
   },
 


### PR DESCRIPTION
This PR resolves https://github.com/brianc/node-sql/issues/323 by only changing the statement into a select if arguments doesn't exist or if it is an empty array. If arguments just an object then an insert statement is generated.
