### PR TITLE
Fix adding/dropping columns with Oracle

### DIFF
--- a/lib/dialect/oracle.js
+++ b/lib/dialect/oracle.js
@@ -28,6 +28,56 @@ Oracle.prototype.visitAlias = function(alias) {
   return result;
 };
 
+Oracle.prototype.visitAlter = function(alter) {
+  var self=this;
+  var errMsg='ALTER TABLE cannot be used to perform multiple different operations in the same statement.';
+
+  // Implement our own add column:
+  //   PostgreSQL: ALTER TABLE "name" ADD COLUMN "col1", ADD COLUMN "col2"
+  //   Oracle:  ALTER TABLE "name" ADD ("col1", "col2")
+  function _addColumn(){
+    self._visitingAlter = true;
+    var table = self._queryNode.table;
+    self._visitingAddColumn = true;
+    var result='ALTER TABLE '+self.visit(table.toNode())+' ADD ('+self.visit(alter.nodes[0].nodes[0]);
+    for (var i= 1,len=alter.nodes.length; i<len; i++){
+      var node=alter.nodes[i];
+      assert(node.type=='ADD COLUMN',errMsg);
+      result+=', '+self.visit(node.nodes[0]);
+    }
+    result+=')';
+    self._visitingAddColumn = false;
+    self._visitingAlter = false;
+    return [result];
+  }
+
+  // Implement our own drop column:
+  //   PostgreSQL: ALTER TABLE "name" DROP COLUMN "col1", DROP COLUMN "col2"
+  //   Oracle:  ALTER TABLE "name" DROP ("col1", "col2")
+  function _dropColumn(){
+    self._visitingAlter = true;
+    var table = self._queryNode.table;
+    var result=[
+      'ALTER TABLE',
+      self.visit(table.toNode())
+    ];
+    var columns='DROP ('+self.visit(alter.nodes[0].nodes[0]);
+    for (var i= 1,len=alter.nodes.length; i<len; i++){
+      var node=alter.nodes[i];
+      assert(node.type=='DROP COLUMN',errMsg);
+      columns+=', '+self.visit(node.nodes[0]);
+    }
+    columns+=')';
+    result.push(columns);
+    self._visitingAlter = false;
+    return result;
+  }
+
+  if (isAlterAddColumn(alter)) return _addColumn();
+  if (isAlterDropColumn(alter)) return _dropColumn();
+  return Oracle.super_.prototype.visitAlter.call(this, alter);
+};
+
 Oracle.prototype.visitTable = function(tableNode) {
   var table = tableNode.table;
   var txt="";
@@ -256,5 +306,16 @@ function isCountStarExpression(columnNode){
   return true;
 }
 
+function isAlterAddColumn(alter){
+  if (alter.nodes.length===0) return false;
+  if (alter.nodes[0].type!='ADD COLUMN') return false;
+  return true;
+}
+
+function isAlterDropColumn(alter){
+  if (alter.nodes.length===0) return false;
+  if (alter.nodes[0].type!='DROP COLUMN') return false;
+  return true;
+}
 
 module.exports = Oracle;

--- a/test/dialects/alter-table-tests.js
+++ b/test/dialects/alter-table-tests.js
@@ -22,6 +22,10 @@ Harness.test({
     text  : 'ALTER TABLE [post] DROP COLUMN [content]',
     string: 'ALTER TABLE [post] DROP COLUMN [content]'
   },
+  oracle: {
+    text  : 'ALTER TABLE "post" DROP ("content")',
+    string: 'ALTER TABLE "post" DROP ("content")'
+  },
   params: []
 });
 
@@ -43,6 +47,10 @@ Harness.test({
     text  : 'ALTER TABLE [post] DROP COLUMN [content], [userId]',
     string: 'ALTER TABLE [post] DROP COLUMN [content], [userId]'
   },
+  oracle: {
+    text  : 'ALTER TABLE "post" DROP ("content", "userId")',
+    string: 'ALTER TABLE "post" DROP ("content", "userId")'
+  },
   params: []
 });
 
@@ -63,6 +71,10 @@ Harness.test({
   mssql: {
     text  : 'ALTER TABLE [post] DROP COLUMN [content], [userId]',
     string: 'ALTER TABLE [post] DROP COLUMN [content], [userId]'
+  },
+  oracle: {
+    text  : 'ALTER TABLE "post" DROP ("content", "userId")',
+    string: 'ALTER TABLE "post" DROP ("content", "userId")'
   },
   params: []
 });
@@ -118,6 +130,10 @@ Harness.test({
     text  : 'ALTER TABLE [group] ADD [id] varchar(100)',
     string: 'ALTER TABLE [group] ADD [id] varchar(100)'
   },
+  oracle: {
+    text  : 'ALTER TABLE "group" ADD ("id" varchar(100))',
+    string: 'ALTER TABLE "group" ADD ("id" varchar(100))'
+  },
   params: []
 });
 
@@ -139,6 +155,10 @@ Harness.test({
     text  : 'ALTER TABLE [group] ADD [id] varchar(100), [userId] varchar(100)',
     string: 'ALTER TABLE [group] ADD [id] varchar(100), [userId] varchar(100)'
   },
+  oracle: {
+    text  : 'ALTER TABLE "group" ADD ("id" varchar(100), "userId" varchar(100))',
+    string: 'ALTER TABLE "group" ADD ("id" varchar(100), "userId" varchar(100))'
+  },
   params: []
 });
 
@@ -159,6 +179,10 @@ Harness.test({
   mssql: {
     text  : 'ALTER TABLE [group] ADD [id] varchar(100), [userId] varchar(100)',
     string: 'ALTER TABLE [group] ADD [id] varchar(100), [userId] varchar(100)'
+  },
+  oracle: {
+    text  : 'ALTER TABLE "group" ADD ("id" varchar(100), "userId" varchar(100))',
+    string: 'ALTER TABLE "group" ADD ("id" varchar(100), "userId" varchar(100))'
   },
   params: []
 });
@@ -286,8 +310,8 @@ Harness.test({
     string: 'ALTER TABLE `post` ADD COLUMN `userId` int REFERENCES `user`(`id`)'
   },
   oracle: {
-    text  : 'ALTER TABLE "post" ADD COLUMN "userId" int REFERENCES "user"("id")',
-    string: 'ALTER TABLE "post" ADD COLUMN "userId" int REFERENCES "user"("id")'
+    text  : 'ALTER TABLE "post" ADD ("userId" int REFERENCES "user"("id"))',
+    string: 'ALTER TABLE "post" ADD ("userId" int REFERENCES "user"("id"))'
   },
   params: []
 });
@@ -307,8 +331,8 @@ Harness.test({
     string: 'ALTER TABLE `post` ADD COLUMN `picture` varchar(100)'
   },
   oracle: {
-    text  : 'ALTER TABLE "post" ADD COLUMN "picture" varchar(100)',
-    string: 'ALTER TABLE "post" ADD COLUMN "picture" varchar(100)'
+    text  : 'ALTER TABLE "post" ADD ("picture" varchar(100))',
+    string: 'ALTER TABLE "post" ADD ("picture" varchar(100))'
   },
   params: []
 });


### PR DESCRIPTION
This PR addresses https://github.com/brianc/node-sql/issues/332 by changing the way the SQL statement is generated when adding/dropping tables using the Oracle dialect.
