### PR TITLE
use browserify-safe require statements

### DIFF
--- a/lib/dialect/mssql.js
+++ b/lib/dialect/mssql.js
@@ -20,7 +20,7 @@ var Mssql = function(config) {
   this.config = config || {};
 };
 
-var Postgres = require(__dirname + '/postgres');
+var Postgres = require('./postgres');
 
 util.inherits(Mssql, Postgres);
 

--- a/lib/dialect/mysql.js
+++ b/lib/dialect/mysql.js
@@ -10,7 +10,7 @@ var Mysql = function(config) {
   this.config = config || {};
 };
 
-var Postgres = require(__dirname + '/postgres');
+var Postgres = require('./postgres');
 
 util.inherits(Mysql, Postgres);
 

--- a/lib/dialect/oracle.js
+++ b/lib/dialect/oracle.js
@@ -9,9 +9,9 @@ var Oracle = function(config) {
   this.config = config || {};
 };
 
-var Postgres = require(__dirname + '/postgres');
+var Postgres = require('./postgres');
 
-var Mssql = require(__dirname + '/mssql');
+var Mssql = require('./mssql');
 
 util.inherits(Oracle, Postgres);
 

--- a/lib/dialect/sqlite.js
+++ b/lib/dialect/sqlite.js
@@ -11,7 +11,7 @@ var Sqlite = function(config) {
   this.config = config || {};
 };
 
-var Postgres = require(__dirname + '/postgres');
+var Postgres = require('./postgres');
 
 util.inherits(Sqlite, Postgres);
 

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,7 +1,7 @@
 'use strict';
 var _ = require('lodash');
 var sliced = require('sliced');
-var FunctionCall = require(__dirname + '/node/functionCall');
+var FunctionCall = require('./node/functionCall');
 
 // create a function that creates a function call of the specific name, using the specified sql instance
 var getFunctionCallCreator = function(name) {

--- a/lib/node/addColumn.js
+++ b/lib/node/addColumn.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'ADD COLUMN'

--- a/lib/node/alias.js
+++ b/lib/node/alias.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
-var Node = require(__dirname);
+var Node = require('./index');
 
 var AliasNode = Node.define({
   type: 'ALIAS',

--- a/lib/node/alter.js
+++ b/lib/node/alter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'ALTER'

--- a/lib/node/arrayCall.js
+++ b/lib/node/arrayCall.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var ParameterNode        = require(__dirname + '/parameter');
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var ParameterNode        = require('./parameter');
+var valueExpressionMixin = require('./valueExpression');
 
 var ArrayCallNode = Node.define({
   type: 'ARRAY CALL',
@@ -18,7 +18,7 @@ var ArrayCallNode = Node.define({
 _.extend(ArrayCallNode.prototype, valueExpressionMixin());
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(ArrayCallNode.prototype, AliasNode.AliasMixin);
 
 module.exports = ArrayCallNode;

--- a/lib/node/at.js
+++ b/lib/node/at.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var valueExpressionMixin = require('./valueExpression');
 
 var valueExpressionMixed = false;
 var AtNode = Node.define({
@@ -21,7 +21,7 @@ var AtNode = Node.define({
 });
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(AtNode.prototype, AliasNode.AliasMixin);
 
 module.exports = AtNode;

--- a/lib/node/binary.js
+++ b/lib/node/binary.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var valueExpressionMixin = require('./valueExpression');
 
 var valueExpressionMixed = false;
 var BinaryNode = Node.define(_.extend({
@@ -23,7 +23,7 @@ var BinaryNode = Node.define(_.extend({
 }));
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(BinaryNode.prototype, AliasNode.AliasMixin);
 
 module.exports = BinaryNode;

--- a/lib/node/cascade.js
+++ b/lib/node/cascade.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'CASCADE'

--- a/lib/node/case.js
+++ b/lib/node/case.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var valueExpressionMixin = require('./valueExpression');
 
 var valueExpressionMixed = false;
 var CaseNode = Node.define(_.extend({
@@ -23,7 +23,7 @@ var CaseNode = Node.define(_.extend({
 }));
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(CaseNode.prototype, AliasNode.AliasMixin);
 
 module.exports = CaseNode;

--- a/lib/node/cast.js
+++ b/lib/node/cast.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var valueExpressionMixin = require('./valueExpression');
 
 var valueExpressionMixed = false;
 var CastNode = Node.define({
@@ -21,7 +21,7 @@ var CastNode = Node.define({
 });
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(CastNode.prototype, AliasNode.AliasMixin);
 
 module.exports = CastNode;

--- a/lib/node/column.js
+++ b/lib/node/column.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'COLUMN',

--- a/lib/node/create.js
+++ b/lib/node/create.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'CREATE',

--- a/lib/node/createView.js
+++ b/lib/node/createView.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'CREATE VIEW',

--- a/lib/node/default.js
+++ b/lib/node/default.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = require(__dirname).define({
+module.exports = require('./index').define({
   type: 'DEFAULT',
   value: function() {
     return;

--- a/lib/node/delete.js
+++ b/lib/node/delete.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'DELETE'

--- a/lib/node/distinct.js
+++ b/lib/node/distinct.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'DISTINCT',

--- a/lib/node/distinctOn.js
+++ b/lib/node/distinctOn.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'DISTINCT ON',

--- a/lib/node/drop.js
+++ b/lib/node/drop.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'DROP',

--- a/lib/node/dropColumn.js
+++ b/lib/node/dropColumn.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'DROP COLUMN'

--- a/lib/node/forShare.js
+++ b/lib/node/forShare.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'FOR SHARE'

--- a/lib/node/forUpdate.js
+++ b/lib/node/forUpdate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'FOR UPDATE'

--- a/lib/node/foreignKey.js
+++ b/lib/node/foreignKey.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'FOREIGN KEY',

--- a/lib/node/from.js
+++ b/lib/node/from.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 var From = Node.define({
   type: 'FROM'

--- a/lib/node/functionCall.js
+++ b/lib/node/functionCall.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var ParameterNode        = require(__dirname + '/parameter');
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var ParameterNode        = require('./parameter');
+var valueExpressionMixin = require('./valueExpression');
 
 var FunctionCallNode = Node.define({
   type: 'FUNCTION CALL',
@@ -18,7 +18,7 @@ var FunctionCallNode = Node.define({
 _.extend(FunctionCallNode.prototype, valueExpressionMixin());
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(FunctionCallNode.prototype, AliasNode.AliasMixin);
 
 module.exports = FunctionCallNode;

--- a/lib/node/groupBy.js
+++ b/lib/node/groupBy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'GROUP BY'

--- a/lib/node/having.js
+++ b/lib/node/having.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'HAVING'

--- a/lib/node/ifExists.js
+++ b/lib/node/ifExists.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'IF EXISTS'

--- a/lib/node/ifNotExists.js
+++ b/lib/node/ifNotExists.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'IF NOT EXISTS'

--- a/lib/node/in.js
+++ b/lib/node/in.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var valueExpressionMixin = require('./valueExpression');
 
 var valueExpressionMixed = false;
 var InNode = Node.define(_.extend({
@@ -22,7 +22,7 @@ var InNode = Node.define(_.extend({
 }));
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(InNode.prototype, AliasNode.AliasMixin);
 
 module.exports = InNode;

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -98,4 +98,4 @@ Node.define = function(def) {
 };
 
 module.exports = Node;
-var TextNode = require(__dirname + '/text');
+var TextNode = require('./text');

--- a/lib/node/interval.js
+++ b/lib/node/interval.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Node          = require(__dirname);
-var ParameterNode = require(__dirname + '/parameter');
+var Node          = require('./index');
+var ParameterNode = require('./parameter');
 
 var IntervalNode = Node.define({
   type: 'INTERVAL',

--- a/lib/node/join.js
+++ b/lib/node/join.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 var JoinNode = module.exports = Node.define({
   type: 'JOIN',
   constructor: function(subType, from, to) {

--- a/lib/node/literal.js
+++ b/lib/node/literal.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'LITERAL',

--- a/lib/node/notIn.js
+++ b/lib/node/notIn.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var valueExpressionMixin = require('./valueExpression');
 
 var valueExpressionMixed = false;
 var NotInNode = Node.define(_.extend({
@@ -22,7 +22,7 @@ var NotInNode = Node.define(_.extend({
 }));
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(NotInNode.prototype, AliasNode.AliasMixin);
 
 module.exports = NotInNode;

--- a/lib/node/onConflict.js
+++ b/lib/node/onConflict.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'ONCONFLICT'

--- a/lib/node/onDuplicate.js
+++ b/lib/node/onDuplicate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'ONDUPLICATE'

--- a/lib/node/orIgnore.js
+++ b/lib/node/orIgnore.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'OR IGNORE'

--- a/lib/node/orderBy.js
+++ b/lib/node/orderBy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'ORDER BY'

--- a/lib/node/orderByValue.js
+++ b/lib/node/orderByValue.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 var OrderByColumn = Node.define({
   type: 'ORDER BY VALUE',

--- a/lib/node/parameter.js
+++ b/lib/node/parameter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 var ParameterNode = module.exports = Node.define({
   type: 'PARAMETER',

--- a/lib/node/postfixUnary.js
+++ b/lib/node/postfixUnary.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var valueExpressionMixin = require('./valueExpression');
 
 var valueExpressionMixed = false;
 var PostfixUnaryNode = Node.define({
@@ -22,7 +22,7 @@ var PostfixUnaryNode = Node.define({
 });
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(PostfixUnaryNode.prototype, AliasNode.AliasMixin);
 
 module.exports = PostfixUnaryNode;

--- a/lib/node/prefixUnary.js
+++ b/lib/node/prefixUnary.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var valueExpressionMixin = require('./valueExpression');
 
 var valueExpressionMixed = false;
 var PrefixUnaryNode = Node.define({
@@ -22,7 +22,7 @@ var PrefixUnaryNode = Node.define({
 });
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(PrefixUnaryNode.prototype, AliasNode.AliasMixin);
 
 module.exports = PrefixUnaryNode;

--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var _ = require('lodash');
-var alias = require(__dirname + '/alias');
+var alias = require('./alias');
 var assert = require('assert');
 var sliced = require('sliced');
 var util   = require('util');
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var valueExpressionMixin = require('./valueExpression');
 
 var Node            = require('./');
 var Select          = require('./select');

--- a/lib/node/rename.js
+++ b/lib/node/rename.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'RENAME'

--- a/lib/node/renameColumn.js
+++ b/lib/node/renameColumn.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'RENAME COLUMN'

--- a/lib/node/restrict.js
+++ b/lib/node/restrict.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'RESTRICT'

--- a/lib/node/returning.js
+++ b/lib/node/returning.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'RETURNING'

--- a/lib/node/select.js
+++ b/lib/node/select.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'SELECT',

--- a/lib/node/slice.js
+++ b/lib/node/slice.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var valueExpressionMixin = require('./valueExpression');
 
 var valueExpressionMixed = false;
 var SliceNode = Node.define({
@@ -22,7 +22,7 @@ var SliceNode = Node.define({
 });
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(SliceNode.prototype, AliasNode.AliasMixin);
 
 module.exports = SliceNode;

--- a/lib/node/table.js
+++ b/lib/node/table.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 module.exports = Node.define({
   type: 'TABLE',
   constructor: function(table) {

--- a/lib/node/ternary.js
+++ b/lib/node/ternary.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var _                    = require('lodash');
-var Node                 = require(__dirname);
-var valueExpressionMixin = require(__dirname + '/valueExpression');
+var Node                 = require('./index');
+var valueExpressionMixin = require('./valueExpression');
 
 var valueExpressionMixed = false;
 var TernaryNode = Node.define(_.extend({
@@ -25,7 +25,7 @@ var TernaryNode = Node.define(_.extend({
 }));
 
 // allow aliasing
-var AliasNode = require(__dirname + '/alias');
+var AliasNode = require('./alias');
 _.extend(TernaryNode.prototype, AliasNode.AliasMixin);
 
 module.exports = TernaryNode;

--- a/lib/node/text.js
+++ b/lib/node/text.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'TEXT',

--- a/lib/node/truncate.js
+++ b/lib/node/truncate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'TRUNCATE',

--- a/lib/node/update.js
+++ b/lib/node/update.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Node = require(__dirname);
+var Node = require('./index');
 
 module.exports = Node.define({
   type: 'UPDATE'

--- a/lib/node/where.js
+++ b/lib/node/where.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var Node = require(__dirname);
-var BinaryNode = require(__dirname + '/binary');
-var TextNode = require(__dirname + '/text');
+var Node = require('./index');
+var BinaryNode = require('./binary');
+var TextNode = require('./text');
 
 var normalizeNode = function(table, node) {
   var result = node;

--- a/lib/table.js
+++ b/lib/table.js
@@ -3,13 +3,13 @@
 var util = require('util');
 var lodash = require('lodash');
 
-var Query = require(__dirname + '/node/query');
-var Column = require(__dirname + '/column');
-var TableNode = require(__dirname + '/node/table');
-var JoinNode = require(__dirname + '/node/join');
-var LiteralNode = require(__dirname + '/node/literal');
-var Joiner = require(__dirname + '/joiner');
-var ForeignKeyNode = require(__dirname + '/node/foreignKey');
+var Query = require('./node/query');
+var Column = require('./column');
+var TableNode = require('./node/table');
+var JoinNode = require('./node/join');
+var LiteralNode = require('./node/literal');
+var Joiner = require('./joiner');
+var ForeignKeyNode = require('./node/foreignKey');
 
 var Table = function(config) {
   this._schema = config.schema;


### PR DESCRIPTION
all boils down to _not_ using `__dirname` inside a require call.

Without this trivial change you end up requiring the path `/home/user/something/something/node_modules/sql/lib/node/` breaking builds like `browserify --node -o bundle.js src/index.js`.

I learned this the hard way while trying to understand why my lambda function didn't work.

Sadly this commit changes many files, I left the tests out but, if you prefer, I'll add those as well.