### PR TITLE
Fix order method with empty array generates invalid SQL

### DIFF
--- a/lib/node/query.js
+++ b/lib/node/query.js
@@ -172,6 +172,9 @@ var Query = Node.define({
   order: function() {
     var args = getArrayOrArgsAsArray(arguments);
     var orderBy;
+    if (args.length === 0) {
+      return this;
+    }
     if (this._orderBy) {
       orderBy = this._orderBy;
     } else {

--- a/test/dialects/order-tests.js
+++ b/test/dialects/order-tests.js
@@ -337,3 +337,29 @@ Harness.test({
   },
   params: []
 });
+
+Harness.test({
+  query: post.select(post.content).order([]),
+  pg: {
+    text  : 'SELECT "post"."content" FROM "post"',
+    string: 'SELECT "post"."content" FROM "post"'
+  },
+  sqlite: {
+    text  : 'SELECT "post"."content" FROM "post"',
+    string: 'SELECT "post"."content" FROM "post"'
+  },
+  mysql: {
+    text  : 'SELECT `post`.`content` FROM `post`',
+    string: 'SELECT `post`.`content` FROM `post`'
+  },
+  mssql: {
+    text  : 'SELECT [post].[content] FROM [post]',
+    string: 'SELECT [post].[content] FROM [post]'
+  },
+  oracle: {
+    text  : 'SELECT "post"."content" FROM "post"',
+    string: 'SELECT "post"."content" FROM "post"'
+  },
+  params: []
+});
+


### PR DESCRIPTION
Calling `order` with an empty array generates 'ORDER BY' without any sort expression. This PR checks for empty array and skip 'ORDER BY' generation if necessary.