### PR TITLE
Exposes function creation to allow use of unsupported functions

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -13,6 +13,9 @@ var getFunctionCallCreator = function(name) {
 
 // creates a hash of functions for a sql instance
 var getFunctions = function(functionNames) {
+  if (typeof functionNames === 'string')
+    return getFunctionCallCreator(functionNames);
+
   var functions = _.reduce(functionNames, function(reducer, name) {
     reducer[name] = getFunctionCallCreator(name);
     return reducer;
@@ -68,4 +71,5 @@ var getStandardFunctions = function() {
   return getFunctions(standardFunctionNames);
 };
 
+module.exports.getFunctions = getFunctions;
 module.exports.getStandardFunctions = getStandardFunctions;

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ var Sql = function(dialect, config) {
 
   // attach the standard SQL functions to this instance
   this.functions = functions.getStandardFunctions();
+  this.function = functions.getFunctions;
 };
 
 // Define a table

--- a/test/function-tests.js
+++ b/test/function-tests.js
@@ -84,4 +84,10 @@ suite('function', function() {
     assert.equal(query.text, 'SELECT (AVG((DISTINCT((COUNT("user"."id") + MAX("user"."id"))) - MIN("user"."id"))) * $1) FROM "user"');
     assert.equal(query.values[0], 100);
   });
+
+  test('use custom function', function() {
+    var query = user.select(sql.function('PHRASE_TO_TSQUERY')('simple', user.name)).toQuery();
+    assert.equal(query.text, 'SELECT PHRASE_TO_TSQUERY($1, "user"."name") FROM "user"');
+    assert.equal(query.values[0], 'simple');
+  });
 });


### PR DESCRIPTION
Syntax: 
```
Foo.select(sql.function('CUSTOM_FUNCTION)(Foo.baz))
SELECT CUSTOM_FUNCTION("foo"."baz") FROM "foo";
```
This allows users to extend node-sql's capabilities to whatever unsupported or custom functions they wish to use.