### PR TITLE
Add FULL and RIGHT outer joins for all DBs.

### DIFF
--- a/lib/dialect/sqlite.js
+++ b/lib/dialect/sqlite.js
@@ -202,4 +202,12 @@ Sqlite.prototype.visitOrIgnore = function() {
   return ['OR IGNORE'];
 };
 
+Sqlite.prototype.visitJoin = function(join) {
+  var invalidTypes = ['RIGHT', 'FULL OUTER'];
+  if (invalidTypes.indexOf(join.subType) !== -1) {
+    throw new Error('Sqlite does not support a ' + join.subType + ' join');
+  }
+  return Sqlite.super_.prototype.visitJoin.call(this, join);
+};
+
 module.exports = Sqlite;

--- a/lib/node/join.js
+++ b/lib/node/join.js
@@ -19,5 +19,11 @@ var JoinNode = module.exports = Node.define({
   },
   leftJoin: function(other) {
     return new JoinNode('LEFT', this, other);
+  }, 
+  rightJoin: function(other) {
+    return new JoinNode('RIGHT', this, other);
+  },
+  fullOuterJoin: function(other) {
+    return new JoinNode('FULL OUTER', this, other);
   }
 });

--- a/lib/table.js
+++ b/lib/table.js
@@ -237,6 +237,14 @@ Table.prototype.leftJoin = function(other) {
   return new JoinNode('LEFT', this.toNode(), other.toNode());
 };
 
+Table.prototype.fullOuterJoin = function(other) {
+  return new JoinNode('FULL OUTER', this.toNode(), other.toNode());
+};
+
+Table.prototype.rightJoin = function(other) {
+  return new JoinNode('RIGHT', this.toNode(), other.toNode());
+};
+
 // auto-join tables based on column intropsection
 Table.prototype.joinTo = function(other) {
   return Joiner.leftJoin(this, other);

--- a/test/dialects/join-tests.js
+++ b/test/dialects/join-tests.js
@@ -174,3 +174,49 @@ Harness.test({
   },
   params: []
 });
+
+Harness.test({
+  query: user.select(user.name, post.content)
+    .from(user.fullOuterJoin(post)
+    .on(user.id.equals(post.userId))),
+  pg: {
+    text: 'SELECT "user"."name", "post"."content" FROM "user" FULL OUTER JOIN "post" ON ("user"."id" = "post"."userId")',
+    string: 'SELECT "user"."name", "post"."content" FROM "user" FULL OUTER JOIN "post" ON ("user"."id" = "post"."userId")'
+  },
+  mysql: {
+    text: 'SELECT `user`.`name`, `post`.`content` FROM `user` FULL OUTER JOIN `post` ON (`user`.`id` = `post`.`userId`)',
+    string: 'SELECT `user`.`name`, `post`.`content` FROM `user` FULL OUTER JOIN `post` ON (`user`.`id` = `post`.`userId`)'
+  },
+  mssql: {
+    text: 'SELECT [user].[name], [post].[content] FROM [user] FULL OUTER JOIN [post] ON ([user].[id] = [post].[userId])',
+    string: 'SELECT [user].[name], [post].[content] FROM [user] FULL OUTER JOIN [post] ON ([user].[id] = [post].[userId])'
+  },
+  oracle: {
+    text: 'SELECT "user"."name", "post"."content" FROM "user" FULL OUTER JOIN "post" ON ("user"."id" = "post"."userId")',
+    string: 'SELECT "user"."name", "post"."content" FROM "user" FULL OUTER JOIN "post" ON ("user"."id" = "post"."userId")'
+  },
+  params: []
+});
+
+Harness.test({
+  query: user.select(user.name, post.content)
+    .from(user.rightJoin(post)
+    .on(user.id.equals(post.userId))),
+  pg: {
+    text: 'SELECT "user"."name", "post"."content" FROM "user" RIGHT JOIN "post" ON ("user"."id" = "post"."userId")',
+    string: 'SELECT "user"."name", "post"."content" FROM "user" RIGHT JOIN "post" ON ("user"."id" = "post"."userId")'
+  },
+  mysql: {
+    text: 'SELECT `user`.`name`, `post`.`content` FROM `user` RIGHT JOIN `post` ON (`user`.`id` = `post`.`userId`)',
+    string: 'SELECT `user`.`name`, `post`.`content` FROM `user` RIGHT JOIN `post` ON (`user`.`id` = `post`.`userId`)'
+  },
+  mssql: {
+    text: 'SELECT [user].[name], [post].[content] FROM [user] RIGHT JOIN [post] ON ([user].[id] = [post].[userId])',
+    string: 'SELECT [user].[name], [post].[content] FROM [user] RIGHT JOIN [post] ON ([user].[id] = [post].[userId])'
+  },
+  oracle: {
+    text: 'SELECT "user"."name", "post"."content" FROM "user" RIGHT JOIN "post" ON ("user"."id" = "post"."userId")',
+    string: 'SELECT "user"."name", "post"."content" FROM "user" RIGHT JOIN "post" ON ("user"."id" = "post"."userId")'
+  },
+  params: []
+});


### PR DESCRIPTION
There lacked the ability to join with other types of joins. 

I've added in FULL OUTER and RIGHT to enable a more complete set of functionality. It uses the functions `rightJoin()` and `fullOuterJoin()` to access this ability. 

When the dialect is SQLite, it ensures to throw an Error since it's not supported on that platform.