### PR TITLE
TableDefinition.schema should not be required

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -128,7 +128,7 @@ declare module "sql" {
 	}
 	type Table<Name extends string, T> = TableNode & Queryable<T> & Named<Name> & Columns<T> & {
 		getName(): string;
-		getSchema(): string;
+		getSchema(): string | undefined;
 
 		literal(statement: string): any;
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -36,7 +36,7 @@ declare module "sql" {
 
 	interface TableDefinition<Name extends string, Row> {
 		name: Name;
-		schema: string;
+		schema?: string;
 		columns: {[CName in keyof Row]: ColumnDefinition<CName, Row[CName]>};
 		dialect?: SQLDialects;
 		isTemporary?: boolean;


### PR DESCRIPTION
From a quick search, it seems like it is only used by oracle. Regardless, it isn't used in the examples given on the homepage, so it's confusing to have it required in the definition.