### PR TITLE
Add prefix option to star() typings

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -142,7 +142,7 @@ declare module "sql" {
 		select<U>(...nodes:any[]):Query<U>
 		from<U>(table:TableNode):Query<U>
 		from<U>(statement:string):Query<U>
-		star():Column<void, void>
+		star({prefix: string}?):Column<void, void>
 		subQuery<U>():SubQuery<U>
 		columns:Column<void, void>[]
 		sql: SQL;


### PR DESCRIPTION
Table.prototype.star can take in an prefix option.

The pull request is updating the typescript definitions to allow for this.