### PR TITLE
Update vulnerable lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "sliced": "0.0.x",
-    "lodash": "4.1.x"
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
     "jshint": "*",


### PR DESCRIPTION
This is triggering security failures when using [nodesecurity/nsp](https://github.com/nodesecurity/nsp) and will soon also fail in npm due to built-in nsp support.

Pinging @brianc - seems like this one might be a little urgent (its certainly failing any CI checks that use nsp)