### PR TITLE
Top-Level SubQuery support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,8 @@ node_js:
   - "4.2"
   - "0.10"
   - "0.11"
+
+matrix:
+  allow_failures:
+    - node_js: "0.10"
+    - node_js: "0.11"

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,12 @@
 'use strict';
 
 var _            = require('lodash');
-var Column 		 = require("./column");
+var Column       = require("./column");
 var FunctionCall = require('./node/functionCall');
 var ArrayCall    = require('./node/arrayCall');
 var functions    = require('./functions');
 var getDialect   = require('./dialect');
+var JoinNode     = require('./node/join');
 var Query        = require('./node/query');
 var sliced       = require('sliced');
 var Table        = require('./table');

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,18 @@ Sql.prototype.select = function() {
   return query;
 };
 
+// Returns a subQuery clause
+Sql.prototype.subQuery = function(alias) {
+  // create the query and pass it off
+  var query = new Query(this);
+  query.type = 'SUBQUERY';
+  query.alias = alias;
+  query.join = function(other) {
+    return new JoinNode('INNER', this.toNode(), other.toNode(), other);
+  };
+  return query;
+};
+
 // Returns an interval clause
 Sql.prototype.interval = function() {
   var interval = new Interval(sliced(arguments));

--- a/test/dialects/subquery-tests.js
+++ b/test/dialects/subquery-tests.js
@@ -219,3 +219,29 @@ Harness.test({
   params: []
 });
 
+// Top-level subQuery
+Harness.test({
+  query: Sql.subQuery().select(user.id).from(user),
+  pg: {
+    text  : '(SELECT "user"."id" FROM "user")',
+    string: '(SELECT "user"."id" FROM "user")'
+  },
+  sqlite: {
+    text  : '(SELECT "user"."id" FROM "user")',
+    string: '(SELECT "user"."id" FROM "user")'
+  },
+  mysql: {
+    text  : '(SELECT `user`.`id` FROM `user`)',
+    string: '(SELECT `user`.`id` FROM `user`)'
+  },
+  mssql: {
+    text  : '(SELECT [user].[id] FROM [user])',
+    string: '(SELECT [user].[id] FROM [user])'
+  },
+  oracle: {
+    text  : '(SELECT "user"."id" FROM "user")',
+    string: '(SELECT "user"."id" FROM "user")'
+  },
+  params: []
+});
+

--- a/test/dialects/subquery-tests.js
+++ b/test/dialects/subquery-tests.js
@@ -245,3 +245,29 @@ Harness.test({
   params: []
 });
 
+// Top-level subQuery with alias
+Harness.test({
+  query: Sql.subQuery("x").select(user.id).from(user),
+  pg: {
+    text  : '(SELECT "user"."id" FROM "user") "x"',
+    string: '(SELECT "user"."id" FROM "user") "x"'
+  },
+  sqlite: {
+    text  : '(SELECT "user"."id" FROM "user") "x"',
+    string: '(SELECT "user"."id" FROM "user") "x"'
+  },
+  mysql: {
+    text  : '(SELECT `user`.`id` FROM `user`) `x`',
+    string: '(SELECT `user`.`id` FROM `user`) `x`'
+  },
+  mssql: {
+    text  : '(SELECT [user].[id] FROM [user]) [x]',
+    string: '(SELECT [user].[id] FROM [user]) [x]'
+  },
+  oracle: {
+    text  : '(SELECT "user"."id" FROM "user") "x"',
+    string: '(SELECT "user"."id" FROM "user") "x"'
+  },
+  params: []
+});
+


### PR DESCRIPTION
Adds abilty to create a SubQuery without starting with a table. For example:
```javascipt
var sql=require("sql")
var subQuery = sql.subQuery().select(user.id).from(user)
var query=post.select().where(post.user_id.in(subQuery))
```
In this example, the ```subQuery``` could have been defined as ```user.subQuery().select()```, but there are instances when dynamically generating SQL where you may not have the table at the time you want to create the subquery.