### PR TITLE
Update TableDefinition type be compatible with shorthand usage

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -36,13 +36,13 @@ declare module "sql" {
 
 	interface TableDefinition<Name extends string, Row> {
 		name: Name;
-		schema: string;
-		columns: {[CName in keyof Row]: ColumnDefinition<CName, Row[CName]>};
+		columns: string[] | {[CName in Extract<keyof Row, string>]: ColumnDefinition<CName, Row[CName]>};
+		schema?: string;
 		dialect?: SQLDialects;
 		isTemporary?: boolean;
 		foreignKeys?: {
 			table: string,
-			columns: (keyof Row)[],
+			columns: string[] | Extract<keyof Row, string>[],
 			refColumns: string[],
 			onDelete?: 'restrict' | 'cascade' | 'no action' | 'set null' | 'set default';
 			onUpdate?: 'restrict' | 'cascade' | 'no action' | 'set null' | 'set default';


### PR DESCRIPTION
Previous typedef for `TableDefinition` was not compatible with common document usage/examples

```
import * as sql from 'sql';

const user = sql.define({
  name: 'user',
  columns: ['id', 'name', 'email', 'lastLogin'] // string[] not compatible with {[CName in keyof Row]: ColumnDefinition<CName, Row[CName]>}; 
});
```

- `schema` field is optional
- Adding `string[]` as an option for the `column` field
- Additionally, Typescript 2.9 added `number` and `symbol` as part of `keyof` so we need to `Extract` only the `string` keys from `Row`. https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html