### PR TITLE
More Flexible IN Literals

### DIFF
--- a/lib/dialect/postgres.js
+++ b/lib/dialect/postgres.js
@@ -508,6 +508,10 @@ Postgres.prototype.visitIn = function(binary) {
     } else {
       text += '1=0';
     }
+  } else if (binary.right.type === 'LITERAL') {
+    var right=this.visit(binary.right)
+    if (!right || !right[0] || right[0] === '()') text += '1=0'
+    else text += this.visit(binary.left) + ' IN ' + right
   } else {
     text += this.visit(binary.left) + ' IN ' + this.visit(binary.right);
   }

--- a/test/dialects/in-clause-tests.js
+++ b/test/dialects/in-clause-tests.js
@@ -177,3 +177,79 @@ Harness.test({
   },
   params: [1, 2]
 });
+
+Harness.test({
+  query: post.select(post.star()).where(post.id.in(post.literal(''))),
+  pg: {
+    text  : 'SELECT "post".* FROM "post" WHERE (1=0)',
+    string: 'SELECT "post".* FROM "post" WHERE (1=0)'
+  },
+  sqlite: {
+    text  : 'SELECT "post".* FROM "post" WHERE (1=0)',
+    string: 'SELECT "post".* FROM "post" WHERE (1=0)'
+  },
+  mysql: {
+    text  : 'SELECT `post`.* FROM `post` WHERE (1=0)',
+    string: 'SELECT `post`.* FROM `post` WHERE (1=0)'
+  },
+  mssql: {
+    text  : 'SELECT [post].* FROM [post] WHERE (1=0)',
+    string: 'SELECT [post].* FROM [post] WHERE (1=0)'
+  },
+  oracle: {
+    text  : 'SELECT "post".* FROM "post" WHERE (1=0)',
+    string: 'SELECT "post".* FROM "post" WHERE (1=0)'
+  },
+  params: []
+});
+
+Harness.test({
+  query: post.select(post.star()).where(post.id.in(post.literal('()'))),
+  pg: {
+    text  : 'SELECT "post".* FROM "post" WHERE (1=0)',
+    string: 'SELECT "post".* FROM "post" WHERE (1=0)'
+  },
+  sqlite: {
+    text  : 'SELECT "post".* FROM "post" WHERE (1=0)',
+    string: 'SELECT "post".* FROM "post" WHERE (1=0)'
+  },
+  mysql: {
+    text  : 'SELECT `post`.* FROM `post` WHERE (1=0)',
+    string: 'SELECT `post`.* FROM `post` WHERE (1=0)'
+  },
+  mssql: {
+    text  : 'SELECT [post].* FROM [post] WHERE (1=0)',
+    string: 'SELECT [post].* FROM [post] WHERE (1=0)'
+  },
+  oracle: {
+    text  : 'SELECT "post".* FROM "post" WHERE (1=0)',
+    string: 'SELECT "post".* FROM "post" WHERE (1=0)'
+  },
+  params: []
+});
+
+Harness.test({
+  query: post.select(post.star()).where(post.id.in(post.literal('(10,20)'))),
+  pg: {
+    text  : 'SELECT "post".* FROM "post" WHERE ("post"."id" IN (10,20))',
+    string: 'SELECT "post".* FROM "post" WHERE ("post"."id" IN (10,20))'
+  },
+  sqlite: {
+    text  : 'SELECT "post".* FROM "post" WHERE ("post"."id" IN (10,20))',
+    string: 'SELECT "post".* FROM "post" WHERE ("post"."id" IN (10,20))'
+  },
+  mysql: {
+    text  : 'SELECT `post`.* FROM `post` WHERE (`post`.`id` IN (10,20))',
+    string: 'SELECT `post`.* FROM `post` WHERE (`post`.`id` IN (10,20))'
+  },
+  mssql: {
+    text  : 'SELECT [post].* FROM [post] WHERE ([post].[id] IN (10,20))',
+    string: 'SELECT [post].* FROM [post] WHERE ([post].[id] IN (10,20))'
+  },
+  oracle: {
+    text  : 'SELECT "post".* FROM "post" WHERE ("post"."id" IN (10,20))',
+    string: 'SELECT "post".* FROM "post" WHERE ("post"."id" IN (10,20))'
+  },
+  params: []
+});
+


### PR DESCRIPTION
Added flexibility to IN clause processing so if a literal equal to '' or () is passed, it will generate a 1=0.