### PR TITLE
Type change to allow typescript > 2.7.2

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -37,7 +37,7 @@ declare module "sql" {
 	interface TableDefinition<Name extends string, Row> {
 		name: Name;
 		schema: string;
-		columns: {[CName in keyof Row]: ColumnDefinition<CName, Row[CName]>};
+		columns: {[CName in ((keyof Row) & string)]: ColumnDefinition<CName, Row[CName]>};
 		dialect?: SQLDialects;
 		isTemporary?: boolean;
 		foreignKeys?: {


### PR DESCRIPTION
Typescript versions greater than 2.7.2, `keyof` produces `string|number|symbol`, failing on line 40.

One fix is have on lines 19 and 22 `Name extends string|number|symbol` instead of `Name extends string`. But this work around may feel a bit not intuitive.

Change directly on line 40, `&` with `string` does the trick of fitting types.